### PR TITLE
Incorrect variable used in Atr_GetDisenchantValue

### DIFF
--- a/AuctionatorAPI.lua
+++ b/AuctionatorAPI.lua
@@ -74,7 +74,7 @@ end
 -----------------------------------------
 
 function Atr_GetDisenchantValue (item)
-  local itemName, itemLink, quality, iLevel, _, itemType, sSubType, _, _, _, _, itemClass, itemSubClass = GetItemInfo(itemLink);
+  local itemName, itemLink, quality, iLevel, _, itemType, sSubType, _, _, _, _, itemClass, itemSubClass = GetItemInfo(item);
 
 	if (itemLink) then
 		return Atr_CalcDisenchantPrice( itemClass, itemRarity, itemLevel )


### PR DESCRIPTION
This prevented the function from returning any values at all, and instead threw an error:
`1x Auctionator\AuctionatorAPI.lua:78: Usage: GetItemInfo(itemID|"name"|"itemlink")[C]:: in function 'GetItemInfo'`