### PR TITLE
fixes old edit bug and corrects new popup from being called from edit

### DIFF
--- a/AuctionatorConfig.lua
+++ b/AuctionatorConfig.lua
@@ -564,11 +564,12 @@ function Atr_Memorize_Show (isNew)
 end
 
 -----------------------------------------
+local Atr_StackingList_Check
 
 function Atr_StackingList_Edit_OnClick()
 
   Atr_Memorize_Show(false);
-
+  Atr_StackingList_Check = false
 end
 
 -----------------------------------------
@@ -576,6 +577,7 @@ end
 function Atr_StackingList_New_OnClick()
 
   Atr_Memorize_Show(true);
+  Atr_StackingList_Check = true
 
 end
 
@@ -606,8 +608,14 @@ function Atr_Memorize_Save()
   local plist = gStackList_plist;
 
   local key = Atr_Mem_EB_itemName:GetText();
-  if (key == nil or key == "") then
-    StaticPopup_Show( "ATR_MEMORIZE_TEXT_BLANK" )
+  if Atr_StackingList_Check then
+    if (key == nil or key == "") then
+      StaticPopup_Show( "ATR_MEMORIZE_TEXT_BLANK" )
+    else
+      key = Atr_Mem_EB_itemName:GetText()
+    end
+  else
+    key = plist[x].sortkey
   end
 
   if (key and key ~= "") then


### PR DESCRIPTION
This fixes the new issue with the warning popup showing when a user clicks edit and the old issue of if you first edit a sell list then click new and accidentally leave it blank it messes up the indexing.