### PR TITLE
Ceylina sell list edit fix

### DIFF
--- a/AuctionatorConfig.lua
+++ b/AuctionatorConfig.lua
@@ -601,19 +601,18 @@ StaticPopupDialogs[ "ATR_MEMORIZE_TEXT_BLANK" ] = {
 };
 
 function Atr_Memorize_Save()
+  Auctionator.Debug.Message( 'Atr_Memorize_Save' )
 
-  zz ("Saving stacking configuration");
+  local x   = gStackList_SelectedIndex
+  local plist = gStackList_plist
+  local key = Atr_Mem_EB_itemName:GetText()
 
-  local x   = gStackList_SelectedIndex;
-  local plist = gStackList_plist;
-
-  local key = Atr_Mem_EB_itemName:GetText();
   if Atr_StackingList_Check then
-    if (key == nil or key == "") then
+    if key == nil or key == "" then
       StaticPopup_Show( "ATR_MEMORIZE_TEXT_BLANK" )
     end
   else
-    key = plist[x].sortkey
+    key = plist[ x ].sortkey
   end
 
   if (key and key ~= "") then

--- a/AuctionatorConfig.lua
+++ b/AuctionatorConfig.lua
@@ -564,11 +564,12 @@ function Atr_Memorize_Show (isNew)
 end
 
 -----------------------------------------
+local Atr_StackingList_Check
 
 function Atr_StackingList_Edit_OnClick()
 
   Atr_Memorize_Show(false);
-
+  Atr_StackingList_Check = false
 end
 
 -----------------------------------------
@@ -576,6 +577,7 @@ end
 function Atr_StackingList_New_OnClick()
 
   Atr_Memorize_Show(true);
+  Atr_StackingList_Check = true
 
 end
 
@@ -606,8 +608,14 @@ function Atr_Memorize_Save()
   local plist = gStackList_plist;
 
   local key = Atr_Mem_EB_itemName:GetText();
-  if (key == nil or key == "") then
-    StaticPopup_Show( "ATR_MEMORIZE_TEXT_BLANK" )
+  if Atr_StackingList_Check then
+    if (key == nil or key == "") then
+      StaticPopup_Show( "ATR_MEMORIZE_TEXT_BLANK" )
+    else
+      key = Atr_Mem_EB_itemName:GetText()
+    end
+  else
+    key = plist[x].sortkey
   end
 
   if (key and key ~= "") then

--- a/AuctionatorConfig.lua
+++ b/AuctionatorConfig.lua
@@ -611,8 +611,6 @@ function Atr_Memorize_Save()
   if Atr_StackingList_Check then
     if (key == nil or key == "") then
       StaticPopup_Show( "ATR_MEMORIZE_TEXT_BLANK" )
-    else
-      key = Atr_Mem_EB_itemName:GetText()
     end
   else
     key = plist[x].sortkey


### PR DESCRIPTION
Fixes addition of warning popup showing on edit window OK button. 

Also fixes issue if clicking edit then clicking new and accidentally leaving text blank, nothing could then be edited (index nil errors)