### PR TITLE
Exact match on left shift

### DIFF
--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -1795,9 +1795,9 @@ function auctionator_ChatEdit_InsertLink(text)
     end
 
     if item then
-      if IsLeftShiftKeyDown() then
+      if IsRightShiftKeyDown() then
         Atr_SetSearchText( item )
-      elseif IsRightShiftKeyDown() then
+      elseif IsLeftShiftKeyDown() then
         Atr_SetSearchText( zc.QuoteString( item ) )
       end
 


### PR DESCRIPTION
It makes more sense to use the left shift as the exact searching modifier.
At least it does to me, since I always want to do exact searches in the auction house and the left hand will be on the keyboard close to the left shift.