### PR TITLE
merge Horde and Alliance auction house

### DIFF
--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -770,14 +770,14 @@ function Atr_InitScanDB()
   if (AUCTIONATOR_PRICE_DATABASE and AUCTIONATOR_PRICE_DATABASE["__dbversion"] == 4) then
     for realm_fac, data in pairs (AUCTIONATOR_PRICE_DATABASE) do
         zc.md ("migrating Auctionator db to version 5 for:", realm_fac);
-		if realm_fac:find("_Alliance") ~= nil then
-			AUCTIONATOR_PRICE_DATABASE[realm_fac:gsub("_Alliance", "")] = AUCTIONATOR_PRICE_DATABASE[realm_fac]
-			AUCTIONATOR_PRICE_DATABASE[realm_fac] = nil
-		end
-		if realm_fac:find("_Horde") ~= nil then
-			AUCTIONATOR_PRICE_DATABASE[realm_fac:gsub("_Horde", "")] = AUCTIONATOR_PRICE_DATABASE[realm_fac]
-			AUCTIONATOR_PRICE_DATABASE[realm_fac] = nil
-		end
+        if realm_fac:find("_Alliance") ~= nil then
+            AUCTIONATOR_PRICE_DATABASE[realm_fac:gsub("_Alliance", "")] = AUCTIONATOR_PRICE_DATABASE[realm_fac]
+            AUCTIONATOR_PRICE_DATABASE[realm_fac] = nil
+        end
+        if realm_fac:find("_Horde") ~= nil then
+            AUCTIONATOR_PRICE_DATABASE[realm_fac:gsub("_Horde", "")] = AUCTIONATOR_PRICE_DATABASE[realm_fac]
+            AUCTIONATOR_PRICE_DATABASE[realm_fac] = nil
+        end
     end
     AUCTIONATOR_PRICE_DATABASE["__dbversion"] = 5;
   end

--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -700,7 +700,7 @@ end
 function Atr_InitScanDB()
   Auctionator.Debug.Message( 'Atr_InitScanDB' )
 
-  local realm_Faction = GetRealmName().."_"..UnitFactionGroup ("player");
+  local realm_Faction = GetRealmName();
 
   if (AUCTIONATOR_PRICE_DATABASE and AUCTIONATOR_PRICE_DATABASE["__dbversion"] == nil) then -- migrate version 1 to version 2
 
@@ -767,9 +767,24 @@ function Atr_InitScanDB()
     AUCTIONATOR_PRICE_DATABASE["__dbversion"] = 4;
   end
 
+  if (AUCTIONATOR_PRICE_DATABASE and AUCTIONATOR_PRICE_DATABASE["__dbversion"] == 4) then
+    for realm_fac, data in pairs (AUCTIONATOR_PRICE_DATABASE) do
+        zc.md ("migrating Auctionator db to version 5 for:", realm_fac);
+		if realm_fac:find("_Alliance") ~= nil then
+			AUCTIONATOR_PRICE_DATABASE[realm_fac:gsub("_Alliance", "")] = AUCTIONATOR_PRICE_DATABASE[realm_fac]
+			AUCTIONATOR_PRICE_DATABASE[realm_fac] = nil
+		end
+		if realm_fac:find("_Horde") ~= nil then
+			AUCTIONATOR_PRICE_DATABASE[realm_fac:gsub("_Horde", "")] = AUCTIONATOR_PRICE_DATABASE[realm_fac]
+			AUCTIONATOR_PRICE_DATABASE[realm_fac] = nil
+		end
+    end
+    AUCTIONATOR_PRICE_DATABASE["__dbversion"] = 5;
+  end
+  
   if (AUCTIONATOR_PRICE_DATABASE == nil) then
     AUCTIONATOR_PRICE_DATABASE = {};
-    AUCTIONATOR_PRICE_DATABASE["__dbversion"] = 4;
+    AUCTIONATOR_PRICE_DATABASE["__dbversion"] = 5;
   end
 
   if (AUCTIONATOR_PRICE_DATABASE[realm_Faction] == nil) then


### PR DESCRIPTION
All auction house informations are stored for Horde and Alliance. Since Blizzard merged this two auction houses it's not necessary to split that. This Patch merges the old data into one realm-data.