### PR TITLE
Quick scan / quick sell buttons

### DIFF
--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -18,6 +18,7 @@ gAtrZC = addonTable.zc;   -- share with AuctionatorDev
 local recommendElements     = {};
 
 AUCTIONATOR_ENABLE_ALT    = 1;
+AUCTIONATOR_ENABLE_QUICK_SCAN = 1;
 AUCTIONATOR_SHOW_ST_PRICE = 0;
 AUCTIONATOR_SHOW_TIPS   = 1;
 AUCTIONATOR_DEF_DURATION  = "N";    -- none

--- a/AuctionatorConfig.lua
+++ b/AuctionatorConfig.lua
@@ -126,9 +126,10 @@ function Atr_BasicOptionsFrame_Save (frame)
     return;
   end
 
-  local origValues = zc.msg_str (AUCTIONATOR_ENABLE_ALT, AUCTIONATOR_SHOW_ST_PRICE, AUCTIONATOR_DEFTAB, AUCTIONATOR_DEF_DURATION);
+  local origValues = zc.msg_str (AUCTIONATOR_ENABLE_ALT, AUCTIONATOR_ENABLE_QUICK_SCAN, AUCTIONATOR_SHOW_ST_PRICE, AUCTIONATOR_DEFTAB, AUCTIONATOR_DEF_DURATION);
 
   AUCTIONATOR_ENABLE_ALT    = zc.BoolToNum(AuctionatorOption_Enable_Alt_CB:GetChecked ());
+  AUCTIONATOR_ENABLE_QUICK_SCAN    = zc.BoolToNum(AuctionatorOption_Quick_Scan_CB:GetChecked ());
   AUCTIONATOR_SHOW_ST_PRICE = zc.BoolToNum(AuctionatorOption_Show_StartingPrice_CB:GetChecked ());
 
   AUCTIONATOR_DEFTAB      = UIDropDownMenu_GetSelectedValue(AuctionatorOption_Deftab);
@@ -139,7 +140,7 @@ function Atr_BasicOptionsFrame_Save (frame)
   if (Atr_RB_M:GetChecked())  then  AUCTIONATOR_DEF_DURATION = "M"; end;
   if (Atr_RB_L:GetChecked())  then  AUCTIONATOR_DEF_DURATION = "L"; end;
 
-  local newValues = zc.msg_str (AUCTIONATOR_ENABLE_ALT, AUCTIONATOR_SHOW_ST_PRICE, AUCTIONATOR_DEFTAB, AUCTIONATOR_DEF_DURATION);
+  local newValues = zc.msg_str (AUCTIONATOR_ENABLE_ALT, AUCTIONATOR_ENABLE_QUICK_SCAN, AUCTIONATOR_SHOW_ST_PRICE, AUCTIONATOR_DEFTAB, AUCTIONATOR_DEF_DURATION);
 
   if (origValues ~= newValues) then
     zc.msg_anm (ZT ("basic options saved"));
@@ -156,6 +157,7 @@ function Atr_SetupBasicOptionsFrame()
   Atr_BasicOptionsFrame_BTitle:SetText (string.format (ZT("Basic Options for %s"), "|cffffff55"..UnitName("player")));
 
   AuctionatorOption_Enable_Alt_CB:SetChecked      (zc.NumToBool(AUCTIONATOR_ENABLE_ALT));
+  AuctionatorOption_Quick_Scan_CB:SetChecked      (zc.NumToBool(AUCTIONATOR_ENABLE_QUICK_SCAN));
   AuctionatorOption_Show_StartingPrice_CB:SetChecked  (zc.NumToBool(AUCTIONATOR_SHOW_ST_PRICE));
   AuctionatorOption_Enable_Debug_CB:SetChecked( AUCTIONATOR_SAVEDVARS.DEBUG_MODE );
 

--- a/AuctionatorConfig.xml
+++ b/AuctionatorConfig.xml
@@ -141,6 +141,19 @@
         </Scripts>
       </Frame>
 
+      <Frame inherits="Atr_SingleOptionTemplate" name="AuctionatorOption_Quick_Scan">
+        <Anchors>
+          <Anchor point="TOP">
+            <Offset>
+              <AbsDimension y="-115"/>
+            </Offset>
+          </Anchor>
+        </Anchors>
+        <Scripts>
+          <OnLoad>AuctionatorOption_Quick_Scan_CB_Text:SetText ("Enable quick scan (experimentally)");  </OnLoad>
+        </Scripts>
+      </Frame>
+
       <Frame inherits="Atr_SingleOptionTemplate" name="AuctionatorOption_Show_StartingPrice">
         <Anchors>
           <Anchor point="TOP">

--- a/AuctionatorScan.lua
+++ b/AuctionatorScan.lua
@@ -515,7 +515,7 @@ function AtrSearch:AnalyzeResultsPage()
   end
 
   -- scan only one page
-  if self.current_page > 1 then
+  if self.current_page > 1 and AUCTIONATOR_ENABLE_QUICK_SCAN == 1 then
     done = true
   end
 

--- a/AuctionatorScan.lua
+++ b/AuctionatorScan.lua
@@ -514,6 +514,11 @@ function AtrSearch:AnalyzeResultsPage()
     end
   end
 
+  -- scan only one page
+  if self.current_page > 1 then
+    done = true
+  end
+
   if not done then
     self.processing_state = Auctionator.Constants.SearchStates.PRE_QUERY
   end
@@ -732,6 +737,12 @@ function AtrSearch:Continue()
       { queryString, minLevel, maxLevel, self.current_page, nil, nil, false, exactMatch, filter },
       'QUERY AUCTION ITEMS PARAMS'
     )
+
+    -- sort search result by buyout (total, so just the cheapest stacks of 1 item will be used to determine price)
+    SortAuctionClearSort("list")
+    SortAuctionSetSort("list", "buyout")
+    SortAuctionApplySort("list")
+
     QueryAuctionItems (queryString, minLevel, maxLevel, self.current_page, nil, nil, false, exactMatch, filter )
 
     self.query_sent_when  = gAtr_ptime;

--- a/UI/Templates/Frames/Sell.xml
+++ b/UI/Templates/Frames/Sell.xml
@@ -382,6 +382,65 @@
             </Scripts>
           </Button>
 
+
+          <Button name="Atr_SetMaxItems" inherits="UIPanelButtonTemplate"  text="MAX" disabled="true">
+            <Size><AbsDimension x="40" y="20"/>  </Size>
+            <Anchors>
+              <Anchor point="TOPLEFT"><Offset><AbsDimension x="140" y="-190"/></Offset></Anchor>
+            </Anchors>
+            <Scripts>
+              <OnClick>
+                max_stacksize = select(8,GetAuctionSellItemInfo())
+                items_owned = select(9,GetAuctionSellItemInfo())
+                calculated_stacksize = math.floor( items_owned / Atr_Batch_NumAuctions:GetText())
+                to_set_stacksize = calculated_stacksize
+
+                if calculated_stacksize > max_stacksize then
+                 to_set_stacksize = max_stacksize
+                end
+
+                Atr_Batch_Stacksize:SetText(to_set_stacksize)
+              </OnClick>
+            </Scripts>
+          </Button>
+
+          <Button name="Atr_SellBigStack" inherits="UIPanelButtonTemplate"  text="Sell BIG stack" disabled="true">
+            <Size><AbsDimension x="100" y="20"/>  </Size>
+            <Anchors>
+              <Anchor point="TOPLEFT"><Offset><AbsDimension x="12" y="-190"/></Offset></Anchor>
+            </Anchors>
+            <Scripts>
+              <OnClick>
+                max_stacksize = select(8,GetAuctionSellItemInfo())
+                item_amount = select(9,GetAuctionSellItemInfo())
+                num_stacks = math.floor(item_amount/max_stacksize)
+
+                set_stack_to = 1
+                set_items_to = item_amount
+                if num_stacks > 1 then
+                  set_items_to = max_stacksize
+                  set_stack_to = num_stacks
+                end
+
+                Atr_Batch_NumAuctions:SetText(set_stack_to)
+                Atr_Batch_Stacksize:SetText(set_items_to)
+              </OnClick>
+            </Scripts>
+          </Button>
+
+          <Button name="Atr_SellStacksOfOne" inherits="UIPanelButtonTemplate"  text="Sell stacks of 1" disabled="true">
+            <Size><AbsDimension x="100" y="20"/>  </Size>
+            <Anchors>
+              <Anchor point="TOPLEFT"><Offset><AbsDimension x="12" y="-240"/></Offset></Anchor>
+            </Anchors>
+            <Scripts>
+              <OnClick>
+                Atr_Batch_NumAuctions:SetText(select(9,GetAuctionSellItemInfo()))
+                Atr_Batch_Stacksize:SetText(1)
+              </OnClick>
+            </Scripts>
+          </Button>
+
           <Frame name="Atr_Duration" inherits="UIDropDownMenuTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_Duration_Text"><Offset><AbsDimension x="32" y="7"/></Offset></Anchor></Anchors>
             <Scripts>


### PR DESCRIPTION
# Quick scan
I want to propose an experimental solution to high page scanning times. Scanning pages for just 1 item can take up to 2 minutes (e.g. 18 pages of Chaos Crystal), which makes selling items very slow and cumbersome for me. 
I've created a new option "enable quick scan" in Basic options, which limits the scan to just 1 page. The items are ordered by Buyout, so the cheapest stacks will determine the price. In most cases those stacks will be of 1 item, so cheaper (per item) stacks will be ignored. This is a trade-off for really fast selling. In case of buying this should not be used (but it currently is in the implementation below, so this needs change).

On this topic, do you guys know who at Blizzard is in charge for the Lua API ? All we need is a parameter such as `buyoutPerItem` for `SortAuctionSetSort` and we'd only have to scan 1 page for every item (more pages in case we want to buy and first page is just stacks of 1), but you get the idea. They've added this functionality to their own auction house UI a few months ago. I wonder why they haven't modified the API so addon devs can also use it.

# Quick sell buttons
Secondly I've added buttons to the sell menu to quickly set stack and stacksize values. This was something I've missed for a very long time. It makes quick selling so much easier than typing into the edit text fields. The implementation is "quick and dirty" for now and should be refined if the authors want this functionality.