### PR TITLE
added C_ChatInfo namespace prefix to all SendAddonMessage calls

### DIFF
--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -348,7 +348,7 @@ function Atr_SendAddon_VREQ (type, target)
     zz ("sending vreq to", type)
   end
 
-  SendAddonMessage( "ATR", "VREQ_"..AuctionatorVersion, type, target )
+  C_ChatInfo.SendAddonMessage( "ATR", "VREQ_"..AuctionatorVersion, type, target )
 end
 
 -----------------------------------------
@@ -364,14 +364,14 @@ function Atr_OnChatMsgAddon (...)
     )
 
     if zc.StringStartsWith( msg, "VREQ_" ) then
-      SendAddonMessage( "ATR", "V_"..AuctionatorVersion, "WHISPER", sender )
+      C_ChatInfo.SendAddonMessage( "ATR", "V_"..AuctionatorVersion, "WHISPER", sender )
     end
 
     if zc.StringStartsWith (msg, "IREQ_") then
       collectgarbage( "collect" )
       UpdateAddOnMemoryUsage()
       local mem  = math.floor( GetAddOnMemoryUsage("Auctionator") )
-      SendAddonMessage( "ATR", "I_" .. Atr_GetDBsize() .. "_" .. mem .. "_" .. #AUCTIONATOR_SHOPPING_LISTS.."_"..GetRealmFacInfoString(), "WHISPER", sender)
+      C_ChatInfo.SendAddonMessage( "ATR", "I_" .. Atr_GetDBsize() .. "_" .. mem .. "_" .. #AUCTIONATOR_SHOPPING_LISTS.."_"..GetRealmFacInfoString(), "WHISPER", sender)
     end
 
     if zc.StringStartsWith( msg, "V_" ) and time() - VREQ_sent < 5 then

--- a/AuctionatorConfig.xml
+++ b/AuctionatorConfig.xml
@@ -524,7 +524,7 @@
           </Anchor>
         </Anchors>
       </Frame>
-      <EditBox autoFocus="false" inherits="InputBoxTemplate" name="Atr_Starting_Discount" numeric="true">
+      <EditBox autoFocus="false" inherits="InputBoxTemplate" name="Atr_Starting_Discount" numeric="true" bytes="64">
         <Size>
           <AbsDimension x="24" y="20"/>
         </Size>
@@ -533,7 +533,7 @@
             <Offset x="210" y="-286"/>
           </Anchor>
         </Anchors>
-        <FontString bytes="64" inherits="ChatFontNormal"/>
+        <FontString inherits="ChatFontNormal"/>
       </EditBox>
       <Button inherits="UIPanelButtonTemplate" name="$parent_Reset" text="Reset to Default">
         <Size>
@@ -789,7 +789,7 @@
           <OnShow function="Atr_SONumStacks_OnShow"/>
         </Scripts>
       </Frame>
-      <EditBox autoFocus="false" inherits="InputBoxTemplate" name="Atr_Mem_EB_stackSize" numeric="true">
+      <EditBox autoFocus="false" inherits="InputBoxTemplate" name="Atr_Mem_EB_stackSize" numeric="true" bytes="64">
         <Size>
           <AbsDimension x="40" y="20"/>
         </Size>
@@ -800,7 +800,7 @@
             </Offset>
           </Anchor>
         </Anchors>
-        <FontString bytes="64" inherits="ChatFontNormal" justifyH="CENTER"/>
+        <FontString inherits="ChatFontNormal" justifyH="CENTER"/>
       </EditBox>
       <Button inherits="Atr_SmallButtonTemplate" name="Atr_Mem_Forget" text="">
         <Size>
@@ -971,7 +971,7 @@
           </Layer>
         </Layers>
         <Frames>
-          <EditBox autoFocus="false" inherits="InputBoxTemplate" name="Atr_ScanOpts_MaxHistAge" numeric="true">
+          <EditBox autoFocus="false" inherits="InputBoxTemplate" name="Atr_ScanOpts_MaxHistAge" numeric="true" bytes="64">
             <Size>
               <AbsDimension x="40" y="22"/>
             </Size>
@@ -980,7 +980,7 @@
                 <Offset x="220" y="-3"/>
               </Anchor>
             </Anchors>
-            <FontString bytes="64" inherits="ChatFontNormal"/>
+            <FontString inherits="ChatFontNormal"/>
           </EditBox>
         </Frames>
       </Frame>

--- a/AuctionatorShop.lua
+++ b/AuctionatorShop.lua
@@ -1022,12 +1022,12 @@ StaticPopupDialogs["ATR_SL_REQUEST_SHARING"] = {
   OnAccept = function(self)
     gSLpermittedUser = gShpListShareRequester
     Atr_Send_ShoppingListData (gShpListShareRequester)
-    SendAddonMessage ("ATR", "SLREQ_", "WHISPER", gShpListShareRequester)
+    C_ChatInfo.SendAddonMessage ("ATR", "SLREQ_", "WHISPER", gShpListShareRequester)
     return
   end,
   OnCancel = function(self)
     gSLpermittedUser = nil
-    SendAddonMessage ("ATR", "SLPERM_DENIED_", "WHISPER", gShpListShareRequester)
+    C_ChatInfo.SendAddonMessage ("ATR", "SLPERM_DENIED_", "WHISPER", gShpListShareRequester)
     return
   end,
   OnShow = function(self)
@@ -1075,7 +1075,7 @@ function Atr_OnChatMsgAddon_ShoppingListCmds (prefix, msg, distribution, sender)
     gSLpermittedUser    = nil
     gShpListShareRequester  = sender
 
-    SendAddonMessage ("ATR", "SLREQACK_", "WHISPER", gShpListShareRequester)
+    C_ChatInfo.SendAddonMessage ("ATR", "SLREQACK_", "WHISPER", gShpListShareRequester)
 
     StaticPopup_Show ("ATR_SL_REQUEST_SHARING")
   end
@@ -1127,7 +1127,7 @@ function Atr_Send_ShoppingListData (toWhom)
     text = text..Atr_ShpList_Export_GetText (AUCTIONATOR_SHOPPING_LISTS[n])
   end
 
-  SendAddonMessage ("ATR", "SLSTART_", "WHISPER", toWhom)
+  C_ChatInfo.SendAddonMessage ("ATR", "SLSTART_", "WHISPER", toWhom)
 
   local lines = { strsplit("\n", text) }
 
@@ -1139,12 +1139,12 @@ function Atr_Send_ShoppingListData (toWhom)
     for n = 1,#lines do
       local line = strtrim(lines[n])
       if (line ~= "") then
-        SendAddonMessage ("ATR", "SLDATA_"..line, "WHISPER", toWhom)
+        C_ChatInfo.SendAddonMessage ("ATR", "SLDATA_"..line, "WHISPER", toWhom)
       end
     end
   end
 
-  SendAddonMessage ("ATR", "SLEND_", "WHISPER", toWhom)
+  C_ChatInfo.SendAddonMessage ("ATR", "SLEND_", "WHISPER", toWhom)
 
 end
 
@@ -1154,7 +1154,7 @@ function Atr_Send_ShareShoppingListRequest (target)
 
   if (UnitIsPlayer(target)) then
     gSLpermittedUser = target   -- sending this request implicitly grants permission to the target
-    SendAddonMessage ("ATR", "SLPERM_REQ_", "WHISPER", gSLpermittedUser)
+    C_ChatInfo.SendAddonMessage ("ATR", "SLPERM_REQ_", "WHISPER", gSLpermittedUser)
     gRequestSentTime = time()
   else
     zc.msg_anm ("You can only share lists with another player")

--- a/UI/Frames/AdvancedSearchDialog.xml
+++ b/UI/Frames/AdvancedSearchDialog.xml
@@ -66,29 +66,29 @@
         </Scripts>
       </Frame>
 
-      <EditBox name="Atr_AS_Minlevel" autoFocus="false" numeric="true" inherits="InputBoxTemplate">
+      <EditBox name="Atr_AS_Minlevel" autoFocus="false" numeric="true" inherits="InputBoxTemplate" bytes="64">
         <Size x="30" y="20"/>
         <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_AS_LevRange_Label" relativePoint="BOTTOMLEFT"><Offset><AbsDimension x="5" y="-4"/></Offset></Anchor></Anchors>
-        <FontString inherits="ChatFontNormal" bytes="64" justifyH="CENTER" />
+        <FontString inherits="ChatFontNormal" justifyH="CENTER" />
       </EditBox>
 
-      <EditBox name="Atr_AS_Maxlevel" autoFocus="false" numeric="true" inherits="InputBoxTemplate">
+      <EditBox name="Atr_AS_Maxlevel" autoFocus="false" numeric="true" inherits="InputBoxTemplate" bytes="64">
         <Size x="30" y="20"/>
         <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_AS_LevRange_Label" relativePoint="BOTTOMLEFT"><Offset><AbsDimension x="59" y="-4"/></Offset></Anchor></Anchors>
-        <FontString inherits="ChatFontNormal" bytes="64" justifyH="CENTER" />
+        <FontString inherits="ChatFontNormal" justifyH="CENTER" />
       </EditBox>
 
 
-      <EditBox name="Atr_AS_MinItemlevel" autoFocus="false" numeric="true" inherits="InputBoxTemplate" hidden="true">
+      <EditBox name="Atr_AS_MinItemlevel" autoFocus="false" numeric="true" inherits="InputBoxTemplate" hidden="true" bytes="64">
         <Size x="30" y="20"/>
         <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_AS_ILevRange_Label" relativePoint="BOTTOMLEFT"><Offset><AbsDimension x="5" y="-4"/></Offset></Anchor></Anchors>
-        <FontString inherits="ChatFontNormal" bytes="64" justifyH="CENTER" />
+        <FontString inherits="ChatFontNormal" justifyH="CENTER" />
       </EditBox>
 
-      <EditBox name="Atr_AS_MaxItemlevel" autoFocus="false" numeric="true" inherits="InputBoxTemplate" hidden="true">
+      <EditBox name="Atr_AS_MaxItemlevel" autoFocus="false" numeric="true" inherits="InputBoxTemplate" hidden="true" bytes="64">
         <Size x="30" y="20"/>
         <Anchors><Anchor point="TOPLEFT" relativeTo="Atr_AS_ILevRange_Label" relativePoint="BOTTOMLEFT"><Offset><AbsDimension x="59" y="-4"/></Offset></Anchor></Anchors>
-        <FontString inherits="ChatFontNormal" bytes="64" justifyH="CENTER" />
+        <FontString inherits="ChatFontNormal" justifyH="CENTER" />
       </EditBox>
 
       <Button name="Atr_Adv_Search_ResetBut" inherits="Atr_SmallButtonTemplate" text="RESET">

--- a/UI/Frames/BuyConfirmationDialog.xml
+++ b/UI/Frames/BuyConfirmationDialog.xml
@@ -49,14 +49,14 @@
         <Frames>
 
 
-          <EditBox name="Atr_Buy_Confirm_Numstacks" autoFocus="false" numeric="true" inherits="InputBoxTemplate">
+          <EditBox name="Atr_Buy_Confirm_Numstacks" autoFocus="false" numeric="true" inherits="InputBoxTemplate" bytes="64">
             <Size><AbsDimension x="40" y="20"/></Size>
             <Anchors>
               <Anchor point="TOPLEFT" relativeTo="Atr_Buy_Confirm_Text1">
                 <Offset><AbsDimension x="40" y="4"/></Offset>
               </Anchor>
             </Anchors>
-            <FontString inherits="ChatFontNormal" bytes="64" justifyH="CENTER" />
+            <FontString inherits="ChatFontNormal" justifyH="CENTER" />
           </EditBox>
         </Frames>
       </Frame>

--- a/UI/Templates/Frames/Sell.xml
+++ b/UI/Templates/Frames/Sell.xml
@@ -73,10 +73,10 @@
       </Button>
 
 
-      <EditBox name="Atr_Search_Box" autoFocus="false" inherits="InputBoxTemplate">
+      <EditBox name="Atr_Search_Box" autoFocus="false" inherits="InputBoxTemplate" bytes="64">
         <Size><AbsDimension x="260" y="20"/></Size>
         <Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="20" y="-45"/></Offset></Anchor></Anchors>
-        <FontString inherits="ChatFontNormal" bytes="64"/>
+        <FontString inherits="ChatFontNormal" />
 
         <Scripts>
           <OnEnterPressed>
@@ -342,28 +342,28 @@
             </Scripts>
           </Frame>
 
-          <EditBox name="Atr_Batch_NumAuctions" autoFocus="false" numeric="true" inherits="InputBoxTemplate">
+          <EditBox name="Atr_Batch_NumAuctions" autoFocus="false" numeric="true" inherits="InputBoxTemplate" bytes="64">
             <Size><AbsDimension x="40" y="20"/></Size>
             <Anchors>
               <Anchor point="TOPLEFT" relativeTo="Atr_Batch_Stacksize_Text">
                 <Offset><AbsDimension x="-37" y="0"/></Offset>
               </Anchor>
             </Anchors>
-            <FontString inherits="ChatFontNormal" bytes="64" justifyH="CENTER" />
+            <FontString inherits="ChatFontNormal"  justifyH="CENTER" />
             <Scripts>
               <OnTextChanged>Atr_NumAuctionsChangedFunc()</OnTextChanged>
               <OnTabPressed>Atr_Batch_Stacksize:SetFocus()</OnTabPressed>
             </Scripts>
           </EditBox>
 
-          <EditBox name="Atr_Batch_Stacksize" autoFocus="false" numeric="true" inherits="InputBoxTemplate">
+          <EditBox name="Atr_Batch_Stacksize" autoFocus="false" numeric="true" inherits="InputBoxTemplate" bytes="64">
             <Size><AbsDimension x="40" y="20"/></Size>
             <Anchors>
               <Anchor point="TOPLEFT" relativeTo="Atr_Batch_Stacksize_Text">
                 <Offset><AbsDimension x="84" y="0"/></Offset>
               </Anchor>
             </Anchors>
-            <FontString inherits="ChatFontNormal" bytes="64" justifyH="CENTER" />
+            <FontString inherits="ChatFontNormal"  justifyH="CENTER" />
             <Scripts>
               <OnTextChanged>Atr_StackSizeChangedFunc()</OnTextChanged>
               <OnTabPressed>Atr_Batch_NumAuctions:SetFocus()</OnTabPressed>


### PR DESCRIPTION
According to [WoW API](https://wow.gamepedia.com/Patch_8.0.1/API_changes) SendAddonMessage was moved into the C_ChatInfo namespace. This pull request adds the prefix and makes the issue #312 not happen.

Included changes to fix Lua Warnings regarding bytes attribute on the FontString element instead of the parent EditBox element.