### PR TITLE
safety check inside of `Atr_ShowTipWithPricing`

### DIFF
--- a/AuctionatorHints.lua
+++ b/AuctionatorHints.lua
@@ -425,7 +425,9 @@ function Atr_ShowTipWithPricing (tip, link, num)
       -- 11: itemVendorPrice? (big int)
       -- 12: itemClass int
       -- 13: subClass int
-  local itemName, itemLink, itemRarity, _, itemMinLevel, itemType, _, _, _, _, itemVendorPrice, classID = GetItemInfo (link);
+  local itemName, itemLink, itemRarity, _, _, _, _, _, _, _, itemVendorPrice, classID = GetItemInfo (link);
+  if not (itemName and itemLink) then return end
+
   local itemLevel = ItemUpgradeInfo:GetUpgradedItemLevel( itemLink )
 
   local showStackPrices = IsShiftKeyDown();


### PR DESCRIPTION
also `itemMinLevel` and `itemType` variables are unused so just set them onto `_`

this will protect a very edge case when GetItemInfo gives no data