### PR TITLE
Atr_GetStackingPrefs_ByItem fix exact match

### DIFF
--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -4282,6 +4282,13 @@ function Atr_GetStackingPrefs_ByItem (itemLink)
 
     local itemName = GetItemInfo (itemLink);
     local text, spinfo;
+    
+    -- do exact match before partial match
+    for text, spinfo in pairs (AUCTIONATOR_STACKING_PREFS) do
+      if itemName == text then
+        return spinfo.numstacks, spinfo.stacksize
+      end
+    end
 
     for text, spinfo in pairs (AUCTIONATOR_STACKING_PREFS) do
 

--- a/Auctionator.lua
+++ b/Auctionator.lua
@@ -4285,7 +4285,7 @@ function Atr_GetStackingPrefs_ByItem (itemLink)
     
     -- do exact match before partial match
     for text, spinfo in pairs (AUCTIONATOR_STACKING_PREFS) do
-      if itemName == text then
+      if string.lower(itemName) == string.lower(text) then
         return spinfo.numstacks, spinfo.stacksize
       end
     end


### PR DESCRIPTION
Do exact match before partial match when searching for StackingPrefs.
You don't wanna go for 'Crescent Saberfish' when 'Crescent Saberfish Flesh' **EXISTS**!