### PR TITLE
Undo change to BrowseResultsAdded which broke favourites display

### DIFF
--- a/Source/Events/BrowseResultsAdded.lua
+++ b/Source/Events/BrowseResultsAdded.lua
@@ -21,8 +21,7 @@ function Auctionator.Events.BrowseResultsAdded(addedBrowseResults)
 
   Auctionator.Database.AppendResults(addedBrowseResults)
 
-  -- We don't use the C_AuctionHouse.HasFullBrowseResults as it doesn't work.
-  if (#addedBrowseResults > 0) then
+  if not C_AuctionHouse.HasFullBrowseResults() then
     C_AuctionHouse.RequestMoreBrowseResults()
   end
 end


### PR DESCRIPTION
The original change was to make the old full scan method of just searching for "" work. As we have a better fullscan implementation now, the change is no longer needed.

A bug with the API just still causes the last search to be placed below the favourites exists though.