### PR TITLE
[Fixes #571] Resolving throttling issues due to the undercut mixins

### DIFF
--- a/Source/Selling/Mixins/Frame.lua
+++ b/Source/Selling/Mixins/Frame.lua
@@ -15,8 +15,18 @@ local AUCTION_DURATIONS = {
   }
 }
 
+local AUCTIONATOR_THROTTLE_EVENTS = {
+  "AUCTION_HOUSE_THROTTLED_MESSAGE_DROPPED",
+  "AUCTION_HOUSE_THROTTLED_MESSAGE_QUEUED",
+  "AUCTION_HOUSE_THROTTLED_MESSAGE_SENT",
+  "AUCTION_HOUSE_THROTTLED_SYSTEM_READY",
+}
+
 function AuctionatorSellingFrameMixin:OnLoad()
   Auctionator.Debug.Message("AuctionatorSellingFrameMixin:OnLoad()")
+
+  self.throttled = false
+  FrameUtil.RegisterFrameForEvents(self, AUCTIONATOR_THROTTLE_EVENTS)
 
   AuctionatorCommoditySellingMixin.Initialize(self)
   AuctionatorItemSellingMixin.Initialize(self)
@@ -40,6 +50,25 @@ function AuctionatorSellingFrameMixin:OnEvent(eventName, ...)
     self:ProcessCommodityResults(...)
   elseif eventName == "ITEM_SEARCH_RESULTS_UPDATED" then
     self:ProcessItemResults(...)
+
+  elseif eventName == "AUCTION_HOUSE_THROTTLED_MESSSAGE_DROPPED" or
+    eventName == "AUCTION_HOUSE_THROTTLED_MESSAGE_QUEUED" or
+    eventName == "AUCTION_HOUSE_THROTTLED_MESSAGE_SENT" then
+
+    Auctionator.Debug.Message("AuctionatorSellingFrameMixin:OnEvent Throttled")
+
+    self.throttled = true
+
+    self:UpdateItemSellButton()
+    self:UpdateCommoditySellButton()
+
+  elseif eventName == "AUCTION_HOUSE_THROTTLED_SYSTEM_READY" then
+    Auctionator.Debug.Message("AuctionatorSellingFrameMixin:OnEvent No throttling")
+
+    self.throttled = false
+
+    self:UpdateItemSellButton()
+    self:UpdateCommoditySellButton()
   end
 end
 

--- a/Source/Utilities/ApplyThrottlingButton.lua
+++ b/Source/Utilities/ApplyThrottlingButton.lua
@@ -1,0 +1,6 @@
+function Auctionator.Utilities.ApplyThrottlingButton(button, isThrottling)
+  button:SetEnabled(not isThrottling)
+  if isThrottling then
+    button:SetTooltip("Throttled. Waiting for the server.")
+  end
+end

--- a/Source/Utilities/Manifest.xml
+++ b/Source/Utilities/Manifest.xml
@@ -13,6 +13,7 @@
   <Script file="Slice.lua"/>
   <Script file="CreateCountString.lua"/>
   <Script file="CreateMoneyString.lua"/>
+  <Script file="ApplyThrottlingButton.lua"/>
 
   <Script file="VerifyListTypes.lua"/>
   <Script file="ValidatePercentage.lua"/>


### PR DESCRIPTION
* "Post Item" button is greyed out if throttling would cause the auction
to fail to post
* Optimisated (removed) aggregation methods to get the lowest priced
item/commodity