### PR TITLE
[Fixes #577] Store and print version information

### DIFF
--- a/.github/workflows/curse.yml
+++ b/.github/workflows/curse.yml
@@ -25,6 +25,10 @@ jobs:
       uses: einaregilsson/build-number@v2 
       with:
         token: ${{secrets.github_token}}  
+    - name: Store build version for printing on startup
+      run: echo "Auctionator.Constants.CURRENT_VERSION = \"0.0."${{steps.buildnumber.outputs.build_number}}"\"" >Auctionator/Version.lua
+    - name: Set prerelease flag
+      run: echo "Auctionator.Constants.PRERELEASE = true" >>Auctionator/Version.lua
     - name: Create zip
       run: zip -r Auctionator-alpha-0.0.${{steps.buildnumber.outputs.build_number}}.zip ./Auctionator 
     - name: Create Release

--- a/Auctionator.toc
+++ b/Auctionator.toc
@@ -15,4 +15,7 @@ zcUtils.lua
 Locales\Manifest.xml
 Source\Manifest.xml
 
+Version.lua
+
 Auctionator.xml
+

--- a/Source/Events/CoreFrameLoaded.lua
+++ b/Source/Events/CoreFrameLoaded.lua
@@ -47,7 +47,8 @@ local AUCTIONATOR_EVENTS = {
 -- coreFrame: AuctionatorCore Frame (see Auctionator.xml)
 function Auctionator.Events.CoreFrameLoaded(coreFrame)
   Auctionator.Debug.Message("Auctionator.Events.CoreFrameLoaded")
-  Auctionator.Utilities.Message("Pre-release version. Limited functionality due to 8.3 AH updates.");
+  Auctionator.Utilities.PrintVersion()
+  Auctionator.Utilities.Message("Limited functionality due to 8.3 AH updates.");
 
   for _, eventName in ipairs(AUCTIONATOR_EVENTS) do
     coreFrame:RegisterEvent(eventName)

--- a/Source/SlashCmd/Commands.lua
+++ b/Source/SlashCmd/Commands.lua
@@ -6,7 +6,8 @@ local SLASH_COMMAND_DESCRIPTIONS = {
   {commands = "d, debug", message = "Toggle debug mode."},
   {commands = "c, config", message = "Show current configuration values."},
   {commands = "c [toggle-name], config [toggle-name]", message = "Toggle the value of the configuration value [toggle-name]."},
-  {commands = "h, help", message = "Show this help message."}
+  {commands = "v, version", message = "Show current version."},
+  {commands = "h, help", message = "Show this help message."},
 }
 
 function Auctionator.SlashCmd.ToggleDebug()
@@ -66,6 +67,10 @@ function Auctionator.SlashCmd.Config(name)
   else
     Auctionator.Utilities.Message("Unknown config " .. name)
   end
+end
+
+function Auctionator.SlashCmd.Version()
+  Auctionator.Utilities.PrintVersion()
 end
 
 function Auctionator.SlashCmd.Help()

--- a/Source/SlashCmd/Main.lua
+++ b/Source/SlashCmd/Main.lua
@@ -21,6 +21,8 @@ local SLASH_COMMANDS = {
   ["debug"] = Auctionator.SlashCmd.ToggleDebug,
   ["config"] = Auctionator.SlashCmd.Config,
   ["c"] = Auctionator.SlashCmd.Config,
+  ["v"] = Auctionator.SlashCmd.Version,
+  ["version"] = Auctionator.SlashCmd.Version,
   ["h"] = Auctionator.SlashCmd.Help,
   ["help"] = Auctionator.SlashCmd.Help,
 }

--- a/Source/Utilities/Manifest.xml
+++ b/Source/Utilities/Manifest.xml
@@ -14,6 +14,7 @@
   <Script file="CreateCountString.lua"/>
   <Script file="CreateMoneyString.lua"/>
   <Script file="ApplyThrottlingButton.lua"/>
+  <Script file="PrintVersion.lua"/>
 
   <Script file="VerifyListTypes.lua"/>
   <Script file="ValidatePercentage.lua"/>

--- a/Source/Utilities/PrintVersion.lua
+++ b/Source/Utilities/PrintVersion.lua
@@ -1,0 +1,11 @@
+function Auctionator.Utilities.PrintVersion()
+  if Auctionator.Constants.PRERELEASE then
+    Auctionator.Utilities.Message(
+      "Version: " .. Auctionator.Constants.CURRENT_VERSION .. " (pre-release)"
+    )
+  else
+    Auctionator.Utilities.Message(
+      "Version: " .. Auctionator.Constants.CURRENT_VERSION
+    )
+  end
+end

--- a/Version.lua
+++ b/Version.lua
@@ -1,0 +1,2 @@
+Auctionator.Constants.CURRENT_VERSION = "Dev"
+Auctionator.Constants.PRERELEASE = true


### PR DESCRIPTION
Puts the version constants in Auctionator/Version.lua, which are printed later.

Moving the Version.lua file is possible, but as its going to be automatically generated (not handwritten) it felt more "correct" to have it outside the normal code.

The content in it is just for when testing a local checkout (I've got a script on my machine that injects a version number and commit id for when I'm testing though)