### PR TITLE
[Fixes #588] Avoid calling blizzard code when throttled

### DIFF
--- a/Source/Selling/Mixins/Commodity.lua
+++ b/Source/Selling/Mixins/Commodity.lua
@@ -30,7 +30,8 @@ function AuctionatorCommoditySellingMixin:Initialize()
 end
 
 function AuctionatorCommoditySellingMixin:UpdateCommoditySellButton()
-  if AuctionHouseFrame.CommoditiesSellFrame:CanPostItem() then
+  if self.throttled or
+     AuctionHouseFrame.CommoditiesSellFrame:CanPostItem() then
     Auctionator.Utilities.ApplyThrottlingButton(
       AuctionHouseFrame.CommoditiesSellFrame.PostButton,
       self.throttled

--- a/Source/Selling/Mixins/Item.lua
+++ b/Source/Selling/Mixins/Item.lua
@@ -30,7 +30,8 @@ function AuctionatorItemSellingMixin:Initialize()
 end
 
 function AuctionatorItemSellingMixin:UpdateItemSellButton()
-  if AuctionHouseFrame.ItemSellFrame:CanPostItem() then
+  if self.throttled or
+     AuctionHouseFrame.ItemSellFrame:CanPostItem() then
     Auctionator.Utilities.ApplyThrottlingButton(
       AuctionHouseFrame.ItemSellFrame.PostButton,
       self.throttled


### PR DESCRIPTION
I can't verify that this fixes the problem, however (based on reviewing the Blizzard code and the bug report text), the only possible way to get a nil comparison is for `C_AuctionHouse.CalculateCommodityDeposit` to have returned nil, which only happens if the information is missing, however the blizzard code assumes the information will be available. I'd guess that the throttling is what prevents a valid result returning, but I can't be sure.

The call to `C_AuctionHouse.CalculateCommodityDeposit` is buried inside `CanPostItem`, the SellFrame version, which makes a call to the the `CalculateDeposit` function, overridden in the CommoditySellFrame mixin, which makes the API call.