### PR TITLE
[Fixes #614] Show pet auction price tooltip

### DIFF
--- a/Source/Tooltips/Hooks.lua
+++ b/Source/Tooltips/Hooks.lua
@@ -1,6 +1,6 @@
 hooksecurefunc (_G, "BattlePetToolTip_Show",
-  function()
-    BattlePetTooltip:SetPoint("BOTTOM", GameTooltip, "TOP")
+  function(speciesID, ...)
+    Auctionator.Tooltip.AddPetTip(speciesID)
   end
 )
 

--- a/Source/Tooltips/Hooks.lua
+++ b/Source/Tooltips/Hooks.lua
@@ -1,3 +1,9 @@
+hooksecurefunc (_G, "BattlePetToolTip_Show",
+  function()
+    BattlePetTooltip:SetPoint("BOTTOM", GameTooltip, "TOP")
+  end
+)
+
 -- This is called when mousing over an item in your bags
 hooksecurefunc (GameTooltip, "SetBagItem",
   function(tip, bag, slot)

--- a/Source/Tooltips/Main.lua
+++ b/Source/Tooltips/Main.lua
@@ -35,13 +35,7 @@ function Auctionator.Tooltip.ShowTipWithPricing(tooltipFrame, itemLink, itemCoun
   local vendorPrice, disenchantParams, disenchantPrice
   local cannotAuction = 0;
 
-  if Auctionator.Utilities.IsPetItemKey(itemKey) then
-    -- If for a pet the tooltip doesn't have any content, so it shows the first
-    -- line as a title line; larger than the later linjes.
-    tooltipFrame:AddLine(
-      WHITE_FONT_COLOR:WrapTextInColorCode("Auctionator")
-    )
-  else
+  if not Auctionator.Utilities.IsPetItemKey(itemKey) then
     local itemInfo = { GetItemInfo(itemLink) };
     if (#itemInfo) ~= 0 then
       cannotAuction = itemInfo[Auctionator.Constants.ITEM_INFO.BIND_TYPE];
@@ -163,6 +157,30 @@ function Auctionator.Tooltip.AddDisenchantTip (
       L("Disenchant"),
       WHITE_FONT_COLOR:WrapTextInColorCode(
         L("unknown") .. "  "
+      )
+    )
+  end
+end
+
+local PET_TOOLTIP_SPACING = " "
+function Auctionator.Tooltip.AddPetTip(
+  speciesID
+)
+  local key = "p:" .. tostring(speciesID)
+  local price = Auctionator.Database.GetPrice(key)
+  BattlePetTooltip:AddLine(" ")
+  if price ~= nil then
+    BattlePetTooltip:AddLine(
+      L("Auction") .. PET_TOOLTIP_SPACING ..
+      WHITE_FONT_COLOR:WrapTextInColorCode(
+        zc.priceToMoneyString(price)
+      )
+    )
+  else
+    BattlePetTooltip:AddLine(
+      L("Auction") .. PET_TOOLTIP_SPACING ..
+      WHITE_FONT_COLOR:WrapTextInColorCode(
+        "unknown"
       )
     )
   end

--- a/Source/Tooltips/Main.lua
+++ b/Source/Tooltips/Main.lua
@@ -36,9 +36,11 @@ function Auctionator.Tooltip.ShowTipWithPricing(tooltipFrame, itemLink, itemCoun
   local cannotAuction = 0;
 
   if Auctionator.Utilities.IsPetItemKey(itemKey) then
-    if auctionPrice ~= nil then
-      Auctionator.Debug.Message("Pet has AH price "..math.floor(auctionPrice/10000).."g "..math.floor((auctionPrice%10000)/100).."s");
-    end
+    -- If for a pet the tooltip doesn't have any content, so it shows the first
+    -- line as a title line; larger than the later linjes.
+    tooltipFrame:AddLine(
+      WHITE_FONT_COLOR:WrapTextInColorCode("Auctionator")
+    )
   else
     local itemInfo = { GetItemInfo(itemLink) };
     if (#itemInfo) ~= 0 then


### PR DESCRIPTION
To get pet tooltips working we have to hook into yet another function, but the result appears to be reliable.
![image](https://user-images.githubusercontent.com/60280559/77599317-35b3a100-6efc-11ea-9ee6-c86014338db3.png)
