### PR TITLE
Hide price options for advanced search queries

### DIFF
--- a/Source/Tabs/ShoppingLists/Frames/AddItem.xml
+++ b/Source/Tabs/ShoppingLists/Frames/AddItem.xml
@@ -103,7 +103,7 @@
         </Anchors>
       </Frame>
 
-      <Frame inherits="AuctionatorConfigurationMinMaxFrame" parentKey="PriceRange">
+      <Frame inherits="AuctionatorConfigurationMinMaxFrame" parentKey="PriceRange" hidden="true">
         <KeyValues>
           <KeyValue key="titleText" value="AUCTIONATOR_L_PRICE" type="global"/>
         </KeyValues>


### PR DESCRIPTION
As this doesn't work as intended, including that only prices up to 999 can be entered, hiding it is preferable to explaining why it has these limitations