### PR TITLE
[Fixes #701] Remove "index" field from shopping lists

### DIFF
--- a/Source/ShoppingLists/Main.lua
+++ b/Source/ShoppingLists/Main.lua
@@ -1,7 +1,6 @@
 function Auctionator.ShoppingLists.Create(listName)
   table.insert(Auctionator.ShoppingLists.Lists, {
     name = listName,
-    index = #Auctionator.ShoppingLists.Lists + 1,
     items = {}
   })
 end

--- a/Source/ShoppingLists/Mixins/ListRenameButton.lua
+++ b/Source/ShoppingLists/Mixins/ListRenameButton.lua
@@ -27,7 +27,10 @@ function AuctionatorListRenameButtonMixin:OnClick()
 end
 
 function AuctionatorListRenameButtonMixin:RenameList(newListName)
-  Auctionator.ShoppingLists.Rename(self.currentList.index, newListName)
+  Auctionator.ShoppingLists.Rename(
+    Auctionator.ShoppingLists.ListIndex(self.currentList.name),
+    newListName
+  )
 
   Auctionator.EventBus:Fire(self, ListRenamed, self.currentList)
 end


### PR DESCRIPTION
Old format was

```lua
{items, name, isSorted}
```

New format was

```lua
{items, name, index}
```

The missing index field causes a nil reference error when renaming:
![image](https://user-images.githubusercontent.com/60280559/80837836-84391700-8bef-11ea-9838-8aa1b51368ca.png)
