### PR TITLE
[Fixes #805] Reconfigure sale item frame to accommodate bid pricing

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -263,6 +263,7 @@ AUCTIONATOR_LOCALES.enUS = function()
   L["PROFILE_TOGGLE_TOOLTIP_TEXT"] = "Makes changes to the Auctionator settings only affect this character."
 
   L["BUYOUT_PRICE"] = "Buyout Price"
+  L["BID_PRICE"] = "Bid Price"
   L["DURATION"] = "Duration"
   L["POST"] = "Post"
   L["POST_BUTTON_MACRO"] = "Post Button Macro"

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -269,6 +269,8 @@ AUCTIONATOR_LOCALES.enUS = function()
   L["POST_BUTTON_MACRO"] = "Post Button Macro"
   L["DEPOSIT"] = "Deposit:"
   L["TOTAL_PRICE"] = "Total Price:"
+  L["ENABLE_BIDDING"] = "Enable Bidding"
+  L["ENABLE_BIDDING_TOOLTIP_TEXT"] = "Toggle bidding for non-commodity items"
 
   L["DEFAULT_TAB"] = "Default Tab"
   L["DEFAULT_TAB_TEXT"] = "shows as the default tab"

--- a/Source/Components/Mixins/CheckBox.lua
+++ b/Source/Components/Mixins/CheckBox.lua
@@ -30,3 +30,9 @@ end
 function AuctionatorConfigCheckboxMixin:GetChecked()
   return self.CheckBox:GetChecked()
 end
+
+function AuctionatorConfigCheckboxMixin:OnCheckChanged(callback)
+  self.CheckBox:SetScript("OnClick", function()
+    callback(self:GetChecked())
+  end)
+end

--- a/Source/Components/Mixins/HorizontalRadioButtonGroup.lua
+++ b/Source/Components/Mixins/HorizontalRadioButtonGroup.lua
@@ -2,13 +2,15 @@ AuctionatorConfigHorizontalRadioButtonGroupMixin = CreateFromMixins(AuctionatorC
 
 function AuctionatorConfigHorizontalRadioButtonGroupMixin:SetupRadioButtons()
   local children = { self:GetChildren() }
-  local size = 0
+  local size = 65
+
+  self.GroupHeading:SetPoint("TOPLEFT", self, "TOPLEFT", 0, -5)
 
   for _, child in ipairs(children) do
     if child.isAuctionatorRadio then
       table.insert(self.radioButtons, child)
 
-      child:SetPoint("TOPLEFT", size, -20)
+      child:SetPoint("LEFT", size, 0)
       child.RadioButton.Label:SetPoint("TOPLEFT", 20, -2)
 
       child.onSelectedCallback = function()
@@ -21,5 +23,5 @@ function AuctionatorConfigHorizontalRadioButtonGroupMixin:SetupRadioButtons()
   end
 
   -- 8 is for bottom padding
-  self:SetSize(size, 48)
+  self:SetSize(size, 28)
 end

--- a/Source/Components/Mixins/MoneyInput.lua
+++ b/Source/Components/Mixins/MoneyInput.lua
@@ -21,6 +21,10 @@ function AuctionatorConfigMoneyInputMixin:GetAmount()
   return self.MoneyInput:GetAmount()
 end
 
+function AuctionatorConfigMoneyInputMixin:ResetAmount()
+  self.MoneyInput:Clear()
+end
+
 function AuctionatorConfigMoneyInputMixin:Disable()
   self.MoneyInput.GoldBox:Disable()
   self.MoneyInput.SilverBox:Disable()

--- a/Source/Components/Mixins/MoneyInput.lua
+++ b/Source/Components/Mixins/MoneyInput.lua
@@ -20,3 +20,14 @@ end
 function AuctionatorConfigMoneyInputMixin:GetAmount()
   return self.MoneyInput:GetAmount()
 end
+
+function AuctionatorConfigMoneyInputMixin:Disable()
+  self.MoneyInput.GoldBox:Disable()
+  self.MoneyInput.SilverBox:Disable()
+  self.MoneyInput:Clear()
+end
+
+function AuctionatorConfigMoneyInputMixin:Enable()
+  self.MoneyInput.GoldBox:Enable()
+  self.MoneyInput.SilverBox:Enable()
+end

--- a/Source/Tabs/DataProviders/SearchProvider.lua
+++ b/Source/Tabs/DataProviders/SearchProvider.lua
@@ -5,6 +5,15 @@ local SEARCH_PROVIDER_LAYOUT = {
     headerText = AUCTIONATOR_L_RESULTS_PRICE_COLUMN,
     cellTemplate = "AuctionatorPriceCellTemplate",
     cellParameters = { "price" },
+    width = 140
+  },
+  {
+    headerTemplate = "AuctionatorStringColumnHeaderTemplate",
+    headerParameters = { "bidPrice" },
+    headerText = "Bid Price",
+    cellTemplate = "AuctionatorPriceCellTemplate",
+    cellParameters = { "bidPrice" },
+    width = 140
   },
   {
     headerTemplate = "AuctionatorStringColumnHeaderTemplate",
@@ -115,6 +124,7 @@ function AuctionatorSearchDataProviderMixin:ProcessCommodityResults(itemID)
     local resultInfo = C_AuctionHouse.GetCommoditySearchResultInfo(itemID, index)
     local entry = {
       price = resultInfo.unitPrice,
+      bidPrice = nil,
       owners = resultInfo.owners,
       quantity = resultInfo.quantity,
       level = "0",
@@ -162,7 +172,8 @@ function AuctionatorSearchDataProviderMixin:ProcessItemResults(itemKey)
   for index = C_AuctionHouse.GetNumItemSearchResults(itemKey), 1, -1 do
     local resultInfo = C_AuctionHouse.GetItemSearchResultInfo(itemKey, index)
     local entry = {
-      price = resultInfo.buyoutAmount or resultInfo.bidAmount,
+      price = resultInfo.buyoutAmount,
+      bidPrice = resultInfo.bidAmount,
       level = tostring(resultInfo.itemKey.itemLevel or 0),
       owners = resultInfo.owners,
       quantity = resultInfo.quantity,

--- a/Source/Tabs/ResultsListing/Mixins/PriceCell.lua
+++ b/Source/Tabs/ResultsListing/Mixins/PriceCell.lua
@@ -10,5 +10,10 @@ end
 function AuctionatorPriceCellTemplateMixin:Populate(rowData, index)
   AuctionatorCellMixin.Populate(self, rowData, index)
 
-  self.MoneyDisplay:SetAmount(rowData[self.columnName])
+  if rowData[self.columnName] ~= nil then
+    self.MoneyDisplay:SetAmount(rowData[self.columnName])
+    self:Show()
+  else
+    self:Hide()
+  end
 end

--- a/Source/Tabs/Selling/Frames/SaleItem.xml
+++ b/Source/Tabs/Selling/Frames/SaleItem.xml
@@ -9,6 +9,7 @@
     <Size x="600" y="100" />
 
     <Scripts>
+      <OnLoad method="OnLoad" />
       <OnEvent method="OnEvent" />
       <OnUpdate method="OnUpdate" />
       <OnShow method="OnShow" />
@@ -17,7 +18,7 @@
 
     <Frames>
       <Frame parentKey="TitleArea">
-        <Size y="24" />
+        <Size y="14" />
         <Anchors>
           <Anchor point="TOPLEFT" />
           <Anchor point="RIGHT" />
@@ -27,7 +28,7 @@
           <Layer>
             <FontString parentKey="Text" inherits="GameFontNormalLarge">
               <Anchors>
-                <Anchor point="TOPLEFT" x="9" y="-5" />
+                <Anchor point="TOPLEFT" y="9" />
               </Anchors>
             </FontString>
           </Layer>
@@ -37,16 +38,44 @@
       <Frame parentKey="Icon" inherits="AuctionatorBagItem">
         <Size x="60" y="60" />
         <Anchors>
-          <Anchor point="TOPLEFT" relativeKey="$parent.TitleArea" relativePoint="BOTTOMLEFT" y="-12" />
+          <Anchor point="TOPLEFT" relativeKey="$parent.TitleArea" relativePoint="BOTTOMLEFT" x="-50" y="-10" />
+        </Anchors>
+      </Frame>
+
+      <Frame parentKey="Price" inherits="AuctionatorConfigurationMoneyInputAlternate">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeKey="$parent.Icon" relativePoint="TOPRIGHT"  y="8" />
+        </Anchors>
+
+        <KeyValues>
+          <KeyValue key="labelText" value="AUCTIONATOR_L_BUYOUT_PRICE" type="global"/>
+        </KeyValues>
+      </Frame>
+
+      <Frame parentKey="BidPrice" inherits="AuctionatorConfigurationMoneyInputAlternate">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeKey="$parent.Price" relativePoint="BOTTOMLEFT" y="-27" />
+        </Anchors>
+        <KeyValues>
+          <KeyValue key="labelText" value="AUCTIONATOR_L_BID_PRICE" type="global"/>
+        </KeyValues>
+      </Frame>
+
+      <Frame inherits="AuctionatorConfigurationCheckbox" parentKey="EnableBid">
+        <KeyValues>
+          <KeyValue key="labelText" value="Enable Bid Pricing" type="string" />
+          <KeyValue key="tooltipTitleText" value="Enable Bid Pricing" type="string"/>
+          <KeyValue key="tooltipText" value="Toggle bid pricing for non-commodity items" type="string"/>
+        </KeyValues>
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeKey="$parent.BidPrice" relativePoint="BOTTOMLEFT" y="-20" x="43" />
         </Anchors>
       </Frame>
 
       <Frame parentKey="Quantity" inherits="AuctionatorConfigurationNumericInputAlternate">
         <Anchors>
-          <Anchor point="TOPLEFT" relativeKey="$parent.Icon" relativePoint="TOPRIGHT" y="-2" />
-          <Anchor point="RIGHT" relativeKey="$parent.Icon" relativePoint="RIGHT" x="200"/>
+          <Anchor point="TOPLEFT" relativeKey="$parent.Icon" relativePoint="TOPRIGHT" x="230" y="2" />
         </Anchors>
-
         <KeyValues>
           <KeyValue key="labelText" value="AUCTIONATOR_L_QUANTITY" type="global"/>
         </KeyValues>
@@ -55,54 +84,34 @@
       <Button parentKey="MaxButton" inherits="UIPanelDynamicResizeButtonTemplate" text="AUCTIONATOR_L_MAX">
         <Size x="70" y="22"/>
         <Anchors>
-          <Anchor point="TOPLEFT" relativeKey="$parent.Quantity" relativePoint="TOPRIGHT" x="0" y="4" />
+          <Anchor point="TOPLEFT" relativeKey="$parent.Quantity" relativePoint="TOPRIGHT" x="-160" y="4"/>
         </Anchors>
         <Scripts>
           <OnClick>self:GetParent():SetMax()</OnClick>
         </Scripts>
       </Button>
 
-      <Frame parentKey="Price" inherits="AuctionatorConfigurationMoneyInputAlternate">
-        <Anchors>
-          <Anchor point="TOPLEFT" relativeKey="$parent.Quantity" relativePoint="BOTTOMLEFT" y="10" />
-        </Anchors>
-
-        <KeyValues>
-          <KeyValue key="labelText" value="AUCTIONATOR_L_BUYOUT_PRICE" type="global"/>
-        </KeyValues>
-      </Frame>
-
       <Frame inherits="AuctionatorConfigurationHorizontalRadioButtonGroup" parentKey="Duration">
         <KeyValues>
           <KeyValue key="groupHeadingText" value="AUCTIONATOR_L_DURATION" type="global"/>
         </KeyValues>
         <Anchors>
-          <Anchor point="TOP" relativeKey="$parent.TitleArea" relativePoint="BOTTOM"/>
-          <Anchor point="LEFT" relativeKey="$parent" relativePoint="CENTER" x="50" />
+          <Anchor point="TOPLEFT" relativeKey="$parent.BidPrice" relativePoint="TOPRIGHT" x="-325" y="4"/>
         </Anchors>
         <Frames>
           <Frame inherits="AuctionatorConfigurationRadioButton">
-            <Anchors>
-              <Anchor point="RIGHT" relativeKey="$parent" relativePoint="RIGHT" x="-180" />
-            </Anchors>
             <KeyValues>
               <KeyValue key="labelText" value="12" type="string"/>
               <KeyValue key="value" value="12" type="number"/>
             </KeyValues>
           </Frame>
           <Frame inherits="AuctionatorConfigurationRadioButton">
-            <Anchors>
-              <Anchor point="RIGHT" relativeKey="$parent" relativePoint="RIGHT" x="-130" />
-            </Anchors>
             <KeyValues>
               <KeyValue key="labelText" value="24" type="string"/>
               <KeyValue key="value" value="24" type="number"/>
             </KeyValues>
           </Frame>
           <Frame inherits="AuctionatorConfigurationRadioButton">
-            <Anchors>
-              <Anchor point="RIGHT" relativeKey="$parent" relativePoint="RIGHT" x="-80" />
-            </Anchors>
             <KeyValues>
               <KeyValue key="labelText" value="48" type="string"/>
               <KeyValue key="value" value="48" type="number"/>
@@ -114,7 +123,7 @@
       <Button parentKey="PostButton" inherits="UIPanelDynamicResizeButtonTemplate" text="AUCTIONATOR_L_POST">
         <Size x="194" y="22"/>
         <Anchors>
-          <Anchor point="TOPLEFT" relativeKey="$parent.Duration" relativePoint="BOTTOMLEFT" x="20" />
+          <Anchor point="TOPLEFT" relativeKey="$parent.Duration" relativePoint="BOTTOMLEFT" x="18" y="-5" />
         </Anchors>
         <Scripts>
           <OnClick>self:GetParent():PostItem()</OnClick>
@@ -126,7 +135,7 @@
       <Layer level="BACKGROUND">
         <FontString inherits="GameFontNormal" parentKey="Deposit" Text="AUCTIONATOR_L_DEPOSIT">
           <Anchors>
-            <Anchor point="TOPLEFT" relativePoint="TOPRIGHT" relativeKey="$parent.Duration" x="-10" />
+            <Anchor point="TOPLEFT" relativePoint="TOPRIGHT" relativeKey="$parent.Quantity"  />
           </Anchors>
         </FontString>
       </Layer>

--- a/Source/Tabs/Selling/Frames/SaleItem.xml
+++ b/Source/Tabs/Selling/Frames/SaleItem.xml
@@ -63,12 +63,13 @@
 
       <Frame inherits="AuctionatorConfigurationCheckbox" parentKey="EnableBid">
         <KeyValues>
-          <KeyValue key="labelText" value="Enable Bid Pricing" type="string" />
-          <KeyValue key="tooltipTitleText" value="Enable Bid Pricing" type="string"/>
-          <KeyValue key="tooltipText" value="Toggle bid pricing for non-commodity items" type="string"/>
+          <KeyValue key="labelText" value="AUCTIONATOR_L_ENABLE_BIDDING" type="global" />
+          <KeyValue key="tooltipTitleText" value="AUCTIONATOR_L_ENABLE_BIDDING" type="global"/>
+          <KeyValue key="tooltipText" value="AUCTIONATOR_L_ENABLE_BIDDING_TOOLTIP_TEXT" type="global"/>
         </KeyValues>
         <Anchors>
           <Anchor point="TOPLEFT" relativeKey="$parent.BidPrice" relativePoint="BOTTOMLEFT" y="-20" x="43" />
+          <Anchor point="RIGHT" relativeKey="$parent.BidPrice" relativePoint="LEFT" x="260"/>
         </Anchors>
       </Frame>
 

--- a/Source/Tabs/Selling/Mixins/SaleItem.lua
+++ b/Source/Tabs/Selling/Mixins/SaleItem.lua
@@ -23,6 +23,18 @@ end
 
 AuctionatorSaleItemMixin = {}
 
+function AuctionatorSaleItemMixin:OnLoad()
+  self.BidPrice:Disable()
+
+  self.EnableBid:OnCheckChanged(function(isChecked)
+    if isChecked then
+      self.BidPrice:Enable()
+    else
+      self.BidPrice:Disable()
+    end
+  end)
+end
+
 function AuctionatorSaleItemMixin:OnShow()
   Auctionator.EventBus:Register(self, {
     Auctionator.Selling.Events.BagItemClicked,

--- a/Source/Tabs/Selling/Mixins/SaleItem.lua
+++ b/Source/Tabs/Selling/Mixins/SaleItem.lua
@@ -151,7 +151,7 @@ function AuctionatorSaleItemMixin:ReceiveEvent(event, ...)
     end
 
     self:UpdateSalesPrice(buyoutAmount)
-    self.bidPrice:ResetAmount()
+    self.BidPrice:ResetAmount()
 
   elseif event == Auctionator.AH.Events.ItemKeyInfo then
     local itemKey, itemInfo = ...


### PR DESCRIPTION
The sale item frame layout is a total hack job. I honest to god don't understand why things lay out the way they do, but I got it looking pretty(ish).

* Updated our checkbox component with the ability to set script for change notification
* Horizontal checkbox work done - this is a total hack job too, but it suits the purpose here. Will need a rewrite for the generic case if we want to use horizontal checkbox groups elsewhere
* Updated our money input component to allow us to enable and disable the inputs, clearing the inputs on disable