### PR TITLE
Show bid prices in sell search results

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -263,6 +263,7 @@ AUCTIONATOR_LOCALES.enUS = function()
   L["PROFILE_TOGGLE_TOOLTIP_TEXT"] = "Makes changes to the Auctionator settings only affect this character."
 
   L["BUYOUT_PRICE"] = "Buyout Price"
+  L["BID_PRICE"] = "Bid Price"
   L["DURATION"] = "Duration"
   L["POST"] = "Post"
   L["POST_BUTTON_MACRO"] = "Post Button Macro"

--- a/Source/Tabs/DataProviders/SearchProvider.lua
+++ b/Source/Tabs/DataProviders/SearchProvider.lua
@@ -2,9 +2,18 @@ local SEARCH_PROVIDER_LAYOUT = {
   {
     headerTemplate = "AuctionatorStringColumnHeaderTemplate",
     headerParameters = { "price" },
-    headerText = AUCTIONATOR_L_RESULTS_PRICE_COLUMN,
+    headerText = AUCTIONATOR_L_BUYOUT_PRICE,
     cellTemplate = "AuctionatorPriceCellTemplate",
     cellParameters = { "price" },
+    width = 140
+  },
+  {
+    headerTemplate = "AuctionatorStringColumnHeaderTemplate",
+    headerParameters = { "bidPrice" },
+    headerText = AUCTIONATOR_L_BID_PRICE,
+    cellTemplate = "AuctionatorPriceCellTemplate",
+    cellParameters = { "bidPrice" },
+    width = 140
   },
   {
     headerTemplate = "AuctionatorStringColumnHeaderTemplate",
@@ -115,6 +124,7 @@ function AuctionatorSearchDataProviderMixin:ProcessCommodityResults(itemID)
     local resultInfo = C_AuctionHouse.GetCommoditySearchResultInfo(itemID, index)
     local entry = {
       price = resultInfo.unitPrice,
+      bidPrice = nil,
       owners = resultInfo.owners,
       quantity = resultInfo.quantity,
       level = "0",
@@ -162,14 +172,15 @@ function AuctionatorSearchDataProviderMixin:ProcessItemResults(itemKey)
   for index = C_AuctionHouse.GetNumItemSearchResults(itemKey), 1, -1 do
     local resultInfo = C_AuctionHouse.GetItemSearchResultInfo(itemKey, index)
     local entry = {
-      price = resultInfo.buyoutAmount or resultInfo.bidAmount,
+      price = resultInfo.buyoutAmount,
+      bidPrice = resultInfo.bidAmount,
       level = tostring(resultInfo.itemKey.itemLevel or 0),
       owners = resultInfo.owners,
       quantity = resultInfo.quantity,
       itemLink = resultInfo.itemLink,
       auctionID = resultInfo.auctionID,
       itemType = Auctionator.Constants.ITEM_TYPES.ITEM,
-      canBuy = not (resultInfo.containsOwnerItem or resultInfo.containsAccountItem)
+      canBuy = resultInfo.buyoutAmount ~= nil and not (resultInfo.containsOwnerItem or resultInfo.containsAccountItem)
     }
 
     if itemKey.battlePetSpeciesID ~= nil and entry.itemLink ~= nil then

--- a/Source/Tabs/ResultsListing/Mixins/PriceCell.lua
+++ b/Source/Tabs/ResultsListing/Mixins/PriceCell.lua
@@ -10,5 +10,10 @@ end
 function AuctionatorPriceCellTemplateMixin:Populate(rowData, index)
   AuctionatorCellMixin.Populate(self, rowData, index)
 
-  self.MoneyDisplay:SetAmount(rowData[self.columnName])
+  if rowData[self.columnName] ~= nil then
+    self.MoneyDisplay:SetAmount(rowData[self.columnName])
+    self:Show()
+  else
+    self:Hide()
+  end
 end


### PR DESCRIPTION
This can be added independently of the bidding changes, and doesn't add much complexity (beyond an extra column)

![image](https://user-images.githubusercontent.com/60280559/89321869-5eeaf780-d67b-11ea-844b-4fd76d1008cb.png)

**Edit**: In retrospect, even the extra column makes the view noiser and harder to parse
