### PR TITLE
Fix tooltips for Chinese translator credits

### DIFF
--- a/Source/Tabs/Auctionator/Frames/Main.xml
+++ b/Source/Tabs/Auctionator/Frames/Main.xml
@@ -141,7 +141,7 @@
         <KeyValues>
           <KeyValue key="textureLocation" type="string" value="Interface\AddOns\Auctionator\Images\zhCN"/>
           <KeyValue key="translators" type="string" value="sugymaylis, LvWind"/>
-          <KeyValue key="tooltipTitleText" value="AUCTIONATOR_L_TRANSLATORS_TRADITIONAL_CHINESE" type="global"/>
+          <KeyValue key="tooltipTitleText" value="AUCTIONATOR_L_TRANSLATORS_SIMPLIFIED_CHINESE" type="global"/>
         </KeyValues>
 			  <Anchors>
           <Anchor point="TOPLEFT" relativeKey="$parent.ptBR" relativePoint="BOTTOMLEFT"/>
@@ -152,7 +152,7 @@
         <KeyValues>
           <KeyValue key="textureLocation" type="string" value="Interface\AddOns\Auctionator\Images\zhTW"/>
           <KeyValue key="translators" type="string" value="RainbowUI"/>
-          <KeyValue key="tooltipTitleText" value="AUCTIONATOR_L_TRANSLATORS_SIMPLIFIED_CHINESE" type="global"/>
+          <KeyValue key="tooltipTitleText" value="AUCTIONATOR_L_TRANSLATORS_TRADITIONAL_CHINESE" type="global"/>
         </KeyValues>
 			  <Anchors>
           <Anchor point="TOPLEFT" relativeKey="$parent.zhCN" relativePoint="BOTTOMLEFT"/>


### PR DESCRIPTION
`zhCN` is [Simplified](https://en.wikipedia.org/wiki/Simplified_Chinese_characters), `zhTW` is [Traditional](https://en.wikipedia.org/wiki/Traditional_Chinese_characters).

These are currently around the wrong way in Auctionator:

![Auctionator screenshot](https://user-images.githubusercontent.com/246847/95949453-43019000-0e3a-11eb-9914-e1ec8f044f16.jpg)

The correct way around is shown on [Curseforge's localisation page](https://www.curseforge.com/wow/addons/auctionator/localization):

<img width="668" alt="Curseforge screenshot" src="https://user-images.githubusercontent.com/246847/95949227-c373c100-0e39-11eb-88d3-60ecc2688086.png">

