### PR TITLE
[Fixes #959] Take relevant ilvls into account in auction prices

### DIFF
--- a/Source/API/v1/GetAuctionPrice.lua
+++ b/Source/API/v1/GetAuctionPrice.lua
@@ -22,6 +22,6 @@ function Auctionator.API.v1.GetAuctionPriceByItemLink(callerID, itemLink)
   end
 
   return Auctionator.Database:GetPrice(
-    Auctionator.Utilities.ItemKeyFromLink(itemLink)
+    Auctionator.Utilities.BasicItemKeyFromLink(itemLink)
   )
 end

--- a/Source/Constants/Main.lua
+++ b/Source/Constants/Main.lua
@@ -52,4 +52,5 @@ Auctionator.Constants = {
     EPIC = 4,
   },
   NO_LIST = "",
+  ITEM_LEVEL_THRESHOLD = 190,
 }

--- a/Source/Database/Mixin.lua
+++ b/Source/Database/Mixin.lua
@@ -26,6 +26,16 @@ function Auctionator.DatabaseMixin:GetPrice(itemKey)
   end
 end
 
+function Auctionator.DatabaseMixin:GetFirstPrice(itemKeys)
+  for _, dbKey in ipairs(itemKeys) do
+    local price = self:GetPrice(dbKey)
+    if price then
+      return price
+    end
+  end
+  return nil
+end
+
 --Takes all the items with a list of their prices, and determines the minimum
 --price.
 function Auctionator.DatabaseMixin:ProcessScan(itemIndexes)

--- a/Source/IncrementalScan/Mixins/Frame.lua
+++ b/Source/IncrementalScan/Mixins/Frame.lua
@@ -94,14 +94,17 @@ function AuctionatorIncrementalScanFrameMixin:AddPrices(results)
 
   for _, resultInfo in ipairs(results) do
     if resultInfo.totalQuantity ~= 0 then
-      local itemKey = Auctionator.Utilities.ItemKeyFromBrowseResult(resultInfo)
-      if self.info[itemKey] == nil then
-        self.info[itemKey] = {}
-      end
+      local allItemKeys = Auctionator.Utilities.ItemKeyFromBrowseResult(resultInfo)
 
-      table.insert(self.info[itemKey],
-        { price = resultInfo.minPrice, available = resultInfo.totalQuantity }
-      )
+      for index, itemKey in ipairs(allItemKeys) do
+        if self.info[itemKey] == nil then
+          self.info[itemKey] = {}
+        end
+
+        table.insert(self.info[itemKey],
+          { price = resultInfo.minPrice, available = resultInfo.totalQuantity }
+        )
+      end
     end
   end
 

--- a/Source/PostingHistory/Mixin.lua
+++ b/Source/PostingHistory/Mixin.lua
@@ -50,11 +50,11 @@ end
 
 function Auctionator.PostingHistoryMixin:ReceiveEvent(eventName, eventData)
   if eventName == Auctionator.Selling.Events.AuctionCreated then
-    self:AddEntry(
-      Auctionator.Utilities.ItemKeyFromLink(eventData.itemLink),
-      eventData.buyoutAmount,
-      eventData.quantity
-    )
+    Auctionator.Utilities.ItemKeyFromLinkCallback(eventData.itemLink, function(keys)
+      for _, key in ipairs(keys) do
+        self:AddEntry(key, eventData.buyoutAmount, eventData.quantity)
+      end
+    end)
   end
 end
 

--- a/Source/Tabs/DataProviders/HistoricalPrice.lua
+++ b/Source/Tabs/DataProviders/HistoricalPrice.lua
@@ -54,7 +54,7 @@ function AuctionatorHistoricalPriceProviderMixin:SetItem(itemKey)
   -- Reset columns
   self.onSearchStarted()
 
-  local dbKey = Auctionator.Utilities.ItemKeyFromBrowseResult({ itemKey = itemKey })
+  local dbKey = Auctionator.Utilities.ItemKeyFromBrowseResult({ itemKey = itemKey })[1]
   local entries = Auctionator.Database:GetPriceHistory(dbKey)
 
   for _, entry in ipairs(entries) do

--- a/Source/Tabs/DataProviders/PostingHistory.lua
+++ b/Source/Tabs/DataProviders/PostingHistory.lua
@@ -58,7 +58,7 @@ end
 
 function AuctionatorPostingHistoryProviderMixin:ReceiveEvent(eventName, eventData)
   if eventName == Auctionator.Selling.Events.BagItemClicked then
-    self:SetItem(Auctionator.Utilities.ItemKeyFromBrowseResult({ itemKey = eventData.itemKey }))
+    self:SetItem(Auctionator.Utilities.ItemKeyFromBrowseResult({ itemKey = eventData.itemKey })[1])
 
   elseif eventName == Auctionator.Selling.Events.RefreshHistory and self.currentDBKey ~= nil then
     self:SetItem(self.currentDBKey)

--- a/Source/Tabs/Selling/Mixins/SaleItem.lua
+++ b/Source/Tabs/Selling/Mixins/SaleItem.lua
@@ -219,9 +219,10 @@ function AuctionatorSaleItemMixin:UpdateForNewItem()
 
   self:SetQuantity()
 
-  local price = Auctionator.Database:GetPrice(
+  local price = Auctionator.Database:GetFirstPrice(
     Auctionator.Utilities.ItemKeyFromBrowseResult({ itemKey = self.itemInfo.itemKey })
   )
+
   if price ~= nil then
     self:UpdateSalesPrice(price)
   elseif IsEquipment(self.itemInfo) then
@@ -362,12 +363,14 @@ end
 function AuctionatorSaleItemMixin:ProcessCommodityResults(itemID, ...)
   Auctionator.Debug.Message("AuctionatorSaleItemMixin:ProcessCommodityResults()")
 
-  local dbKey = Auctionator.Utilities.ItemKeyFromBrowseResult({ itemKey = C_AuctionHouse.MakeItemKey(itemID) })
+  local dbKeys = Auctionator.Utilities.ItemKeyFromBrowseResult({ itemKey = C_AuctionHouse.MakeItemKey(itemID) })
 
   local result = self:GetCommodityResult(itemID)
   -- Update DB with current lowest price
   if result ~= nil then
-    Auctionator.Database:SetPrice(dbKey, result.unitPrice)
+    for _, key in ipairs(dbKeys) do
+      Auctionator.Database:SetPrice(key, result.unitPrice)
+    end
   end
 
   -- A few cases to process here:
@@ -380,7 +383,7 @@ function AuctionatorSaleItemMixin:ProcessCommodityResults(itemID, ...)
 
   if result == nil then
     -- This commodity was not found in the AH, so use the last lowest price from DB
-    postingPrice = Auctionator.Database:GetPrice(dbKey)
+    postingPrice = Auctionator.Database:GetFirstPrice(dbKeys)
   elseif result ~= nil and result.containsOwnerItem and result.owners[1] == "player" then
     -- No need to undercut myself
     postingPrice = result.unitPrice
@@ -409,13 +412,15 @@ end
 function AuctionatorSaleItemMixin:ProcessItemResults(itemKey)
   Auctionator.Debug.Message("AuctionatorSaleItemMixin:ProcessItemResults()")
 
-  local dbKey = Auctionator.Utilities.ItemKeyFromBrowseResult({ itemKey = itemKey })
+  local dbKeys = Auctionator.Utilities.ItemKeyFromBrowseResult({ itemKey = itemKey })
 
   local result = self:GetItemResult(itemKey)
 
   -- Update DB with current lowest price
   if result ~= nil then
-    Auctionator.Database:SetPrice(dbKey, result.buyoutAmount or result.bidAmount)
+    for _, key in ipairs(dbKeys) do
+      Auctionator.Database:SetPrice(key, result.buyoutAmount or result.bidAmount)
+    end
   end
 
   local postingPrice = nil
@@ -423,7 +428,7 @@ function AuctionatorSaleItemMixin:ProcessItemResults(itemKey)
   if result == nil then
     -- This item was not found in the AH, so use the lowest price from the dbKey
     -- TODO: DB price does not account for iLvl
-    postingPrice = Auctionator.Database:GetPrice(dbKey)
+    postingPrice = Auctionator.Database:GetFirstPrice(dbKeys)
   elseif result ~= nil and result.containsOwnerItem then
     -- Posting an item I have alread posted, and that is the current lowest price, so just
     -- use this price

--- a/Source/Tooltips/Main.lua
+++ b/Source/Tooltips/Main.lua
@@ -3,8 +3,7 @@ local zc = addonTable.zc;
 
 local L = Auctionator.Locales.Apply
 
-local waitingOnLink = nil
-local waitingForTooltip = nil
+local waitingForPricing = false
 -- Auctionator.Config.Options.VENDOR_TOOLTIPS: true if should show vendor tips
 -- Auctionator.Config.Options.SHIFT_STACK_TOOLTIPS: true to show stack price when [shift] is down
 -- Auctionator.Config.Options.AUCTION_TOOLTIPS: true if should show auction tips
@@ -15,11 +14,9 @@ function Auctionator.Tooltip.ShowTipWithPricing(tooltipFrame, itemLink, itemCoun
   -- Keep this commented out unless testing please.
   -- Auctionator.Debug.Message("Auctionator.Tooltip.ShowTipWithPricing", itemLink, itemCount)
 
-  waitingOnLink = itemLink
-  waitingForTooltip = tooltipFrame
+  waitingForPricing = true
   Auctionator.Utilities.ItemKeyFromLinkCallback(itemLink, function(dbKeys)
-    waitingOnLink = nil
-    waitingForTooltip = nil
+    waitingForPricing = false
     Auctionator.Tooltip.ShowTipWithPricingDBKey(tooltipFrame, dbKeys, itemLink, itemCount)
   end)
 end
@@ -78,12 +75,13 @@ end
 -- Each itemKey entry should contain
 -- link
 -- count
-local isMultiplePricesInProgress = false
+local isMultiplePricesPending = false
 function Auctionator.Tooltip.ShowTipWithMultiplePricing(tooltipFrame, itemEntries)
-  if isMultiplePricesInProgress then
+  if isMultiplePricesPending then
     return
   end
-  isMultiplePricesInProgress = true
+  isMultiplePricesPending = true
+
   local total = 0
   local itemCount = 0
   local itemLinks = {}

--- a/Source/Tooltips/Main.lua
+++ b/Source/Tooltips/Main.lua
@@ -3,16 +3,29 @@ local zc = addonTable.zc;
 
 local L = Auctionator.Locales.Apply
 
+local waitingOnLink = nil
+local waitingForTooltip = nil
 -- Auctionator.Config.Options.VENDOR_TOOLTIPS: true if should show vendor tips
 -- Auctionator.Config.Options.SHIFT_STACK_TOOLTIPS: true to show stack price when [shift] is down
 -- Auctionator.Config.Options.AUCTION_TOOLTIPS: true if should show auction tips
 function Auctionator.Tooltip.ShowTipWithPricing(tooltipFrame, itemLink, itemCount)
+  if waitingOnLink == itemLink and waitingForTooltip == tooltipFrame then
+    return
+  end
   -- Keep this commented out unless testing please.
   -- Auctionator.Debug.Message("Auctionator.Tooltip.ShowTipWithPricing", itemLink, itemCount)
 
-  local itemKey = Auctionator.Utilities.ItemKeyFromLink(itemLink)
+  waitingOnLink = itemLink
+  waitingForTooltip = tooltipFrame
+  Auctionator.Utilities.ItemKeyFromLinkCallback(itemLink, function(dbKeys)
+    waitingOnLink = nil
+    waitingForTooltip = nil
+    Auctionator.Tooltip.ShowTipWithPricingDBKey(tooltipFrame, dbKeys, itemLink, itemCount)
+  end)
+end
 
-  if itemKey == nil or Auctionator.Utilities.IsPetItemKey(itemKey) then
+function Auctionator.Tooltip.ShowTipWithPricingDBKey(tooltipFrame, dbKeys, itemLink, itemCount)
+  if #dbKeys == 0 or Auctionator.Utilities.IsPetItemKey(dbKeys[1]) then
     return
   end
 
@@ -27,7 +40,7 @@ function Auctionator.Tooltip.ShowTipWithPricing(tooltipFrame, itemLink, itemCoun
     countString = Auctionator.Utilities.CreateCountString(itemCount)
   end
 
-  local auctionPrice = Auctionator.Database:GetPrice(itemKey)
+  local auctionPrice = Auctionator.Database:GetFirstPrice(dbKeys)
   if auctionPrice ~= nil then
     auctionPrice = auctionPrice * (showStackPrices and itemCount or 1)
   end
@@ -49,7 +62,7 @@ function Auctionator.Tooltip.ShowTipWithPricing(tooltipFrame, itemLink, itemCoun
   end
 
   if Auctionator.Debug.IsOn() then
-    tooltipFrame:AddDoubleLine("ItemID", itemKey)
+    tooltipFrame:AddDoubleLine("ItemID", dbKey[1])
   end
 
   if vendorPrice ~= nil then
@@ -65,35 +78,44 @@ end
 -- Each itemKey entry should contain
 -- link
 -- count
-function Auctionator.Tooltip.ShowTipWithMultiplePricing(tooltipFrame, itemKeys)
-  local auctionPrice
+local isMultiplePricesInProgress = false
+function Auctionator.Tooltip.ShowTipWithMultiplePricing(tooltipFrame, itemEntries)
+  if isMultiplePricesInProgress then
+    return
+  end
+  isMultiplePricesInProgress = true
   local total = 0
   local itemCount = 0
-
-  for _, itemEntry in ipairs(itemKeys) do
-    tooltipFrame:AddLine(itemEntry.link)
-
-    auctionPrice = Auctionator.Database:GetPrice(
-      Auctionator.Utilities.ItemKeyFromLink(itemEntry.link)
-    )
-    if auctionPrice ~= nil then
-      total = total + (auctionPrice * itemEntry.count)
-    end
-    itemCount = itemCount + itemEntry.count
-
-    Auctionator.Tooltip.ShowTipWithPricing(tooltipFrame, itemEntry.link, itemEntry.count)
+  local itemLinks = {}
+  for _, itemEntry in ipairs(itemEntries) do
+    table.insert(itemLinks, itemEntry.link)
   end
 
-  tooltipFrame:AddLine("  ")
+  Auctionator.Utilities.ItemKeysFromMultipleLinksCallback(itemLinks, function(allKeys)
+    isMultiplePricesInProgress = false
+    for index, dbKeys in ipairs(allKeys) do
+      local itemEntry = itemEntries[index]
 
-  tooltipFrame:AddDoubleLine(
-    Auctionator.Locales.Apply("TOTAL_ITEMS_COLORED", itemCount),
-    WHITE_FONT_COLOR:WrapTextInColorCode(
-      zc.priceToMoneyString(total)
+      tooltipFrame:AddLine(itemEntry.link)
+      Auctionator.Tooltip.ShowTipWithPricingDBKey(tooltipFrame, dbKeys, itemEntry.link, itemEntry.count)
+      local auctionPrice = Auctionator.Database:GetFirstPrice(dbKeys)
+      if auctionPrice ~= nil then
+        total = total + (auctionPrice * itemEntry.count)
+      end
+      itemCount = itemCount + itemEntry.count
+    end
+
+    tooltipFrame:AddLine("  ")
+
+    tooltipFrame:AddDoubleLine(
+      Auctionator.Locales.Apply("TOTAL_ITEMS_COLORED", itemCount),
+      WHITE_FONT_COLOR:WrapTextInColorCode(
+        zc.priceToMoneyString(total)
+      )
     )
-  )
 
-  tooltipFrame:Show()
+    tooltipFrame:Show()
+  end)
 end
 
 function Auctionator.Tooltip.AddVendorTip(tooltipFrame, vendorPrice, countString)

--- a/Source/Utilities/ItemKeyFromBrowseResult.lua
+++ b/Source/Utilities/ItemKeyFromBrowseResult.lua
@@ -1,7 +1,12 @@
 function Auctionator.Utilities.ItemKeyFromBrowseResult(result)
-    if(result.itemKey.battlePetSpeciesID ~= 0) then
-      return "p:" .. tostring(result.itemKey.battlePetSpeciesID)
+    if result.itemKey.battlePetSpeciesID ~= 0 then
+      return {"p:" .. tostring(result.itemKey.battlePetSpeciesID)}
+    elseif result.itemKey.itemLevel >= Auctionator.Constants.ITEM_LEVEL_THRESHOLD then
+      return {
+        "g:" .. result.itemKey.itemID .. ":" .. result.itemKey.itemLevel,
+        tostring(result.itemKey.itemID)
+      }
     else
-      return tostring(result.itemKey.itemID)
+      return {tostring(result.itemKey.itemID)}
     end
 end

--- a/Source/Utilities/ItemKeyFromLink.lua
+++ b/Source/Utilities/ItemKeyFromLink.lua
@@ -1,4 +1,4 @@
-function Auctionator.Utilities.ItemKeyFromLink(itemLink)
+function Auctionator.Utilities.BasicItemKeyFromLink(itemLink)
   if itemLink ~= nil then
     local _, _, itemString = string.find(itemLink, "^|c%x+|H(.+)|h%[.*%]")
     if itemString ~= nil then
@@ -13,16 +13,20 @@ function Auctionator.Utilities.ItemKeyFromLink(itemLink)
   return nil
 end
 
+local function IsGear(itemLink)
+  local classType = select(6, GetItemInfoInstant(itemLink))
+  return classType == LE_ITEM_CLASS_WEAPON or classType == LE_ITEM_CLASS_ARMOR
+end
+
 function Auctionator.Utilities.ItemKeyFromLinkCallback(itemLink, callback)
   if itemLink == nil then
     callback({})
     return
   end
 
-  local basicKey = Auctionator.Utilities.ItemKeyFromLink(itemLink)
+  local basicKey = Auctionator.Utilities.BasicItemKeyFromLink(itemLink)
 
-  local itemInfoInstant = {GetItemInfoInstant(itemLink)}
-  if itemInfoInstant[6] == LE_ITEM_CLASS_WEAPON or itemInfoInstant[6] == LE_ITEM_CLASS_ARMOR then
+  if IsGear(itemLink) then
     local item = Item:CreateFromItemLink(itemLink)
     item:ContinueOnItemLoad(function()
       local itemLevel = GetDetailedItemLevelInfo(itemLink) or 0
@@ -33,7 +37,6 @@ function Auctionator.Utilities.ItemKeyFromLinkCallback(itemLink, callback)
         callback({basicKey})
       end
     end)
-
   else
     callback({basicKey})
   end

--- a/Source/Utilities/ItemKeyFromLink.lua
+++ b/Source/Utilities/ItemKeyFromLink.lua
@@ -12,3 +12,46 @@ function Auctionator.Utilities.ItemKeyFromLink(itemLink)
   end
   return nil
 end
+
+function Auctionator.Utilities.ItemKeyFromLinkCallback(itemLink, callback)
+  if itemLink == nil then
+    callback({})
+    return
+  end
+
+  local basicKey = Auctionator.Utilities.ItemKeyFromLink(itemLink)
+
+  local itemInfoInstant = {GetItemInfoInstant(itemLink)}
+  if itemInfoInstant[6] == LE_ITEM_CLASS_WEAPON or itemInfoInstant[6] == LE_ITEM_CLASS_ARMOR then
+    local item = Item:CreateFromItemLink(itemLink)
+    item:ContinueOnItemLoad(function()
+      local itemLevel = GetDetailedItemLevelInfo(itemLink) or 0
+
+      if itemLevel >= Auctionator.Constants.ITEM_LEVEL_THRESHOLD then
+        callback({"g:" .. basicKey .. ":" .. itemLevel, basicKey})
+      else
+        callback({basicKey})
+      end
+    end)
+
+  else
+    callback({basicKey})
+  end
+end
+
+function Auctionator.Utilities.ItemKeysFromMultipleLinksCallback(itemLinks, callback)
+  local result = {}
+
+  for index, link in ipairs(itemLinks) do
+    Auctionator.Utilities.ItemKeyFromLinkCallback(link, function(dbKeys)
+      result[index] = dbKeys
+
+      for i = 1, #itemLinks do
+        if result[i] == nil then
+          return
+        end
+      end
+      callback(result)
+    end)
+  end
+end


### PR DESCRIPTION
Not every item level is relevant to an item's auction value. To avoid polluting the price data with irrelevant fluctuations due to low item levels we will set a minimum item level to be considered relevant. As of 9.0.2 this is 190, and saved in `Auctionator.Constants.ITEM_LEVEL_THRESHOLD`

When we inevitably move the minimum item level **up** we need the price data to remain and update smoothly. To enable this every gear with a relevant item level will also save its pricing data to an extra database entry that does not include an item level. To support this the functions that return the database key for the item will return arrays.

There are two ways to determine the item level of an item:
1. Use `GetDetailedItemLevelInfo`. This requires that the item is cached by the WoW client, so will need a callback to alert our code when the information becomes available.
2. Precompute the item levels granted by item string bonus IDs. This has the advantage that all price data is available immediately, without needing to wait for the client to load data, however this requires updating the data manually (or via a script) from now until the end of time, and writing a script to obtain accurate data.

For now 1. has been selected, as a result the function call to get the database keys for an item described by an item link is:
```lua
ItemKeyFromLinkCallback(itemLink, function(dbKeys)
  --Use the database keys, dbKeys: str[]
end)
```
When there are multiple item links the following helper function has been created:
```lua
ItemKeysFromMultipleLinksCallback(itemLinks, function(allDBKeys)
  for index, dbKeys in ipairs(allDBKeys) do
    --Where dbKeys corresponds to the item link in itemLinks[index]
  end
end)
```