### PR TITLE
Selling tab: Fix item level checks and remove SELLING_GEAR_USE_ILVL o…

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -395,9 +395,6 @@ AUCTIONATOR_LOCALES.enUS = function()
   L["CONFIG_SELLING_GEAR_VENDOR_PRICE_MULTIPLIER_SUFFIX"] = "Set to 0 for no price"
   L["CONFIG_SELLING_GEAR_VENDOR_PRICE_MULTIPLIER_TOOLTIP_HEADER"] = "Gear Vendor Price Default"
   L["CONFIG_SELLING_GEAR_VENDOR_PRICE_MULTIPLIER_TOOLTIP_TEXT"] = "This lets you set a default price for gear as a multiple of the vendor price. This is used for any gear Auctionator doesn't have a price for. Set this to 0 to not set a price."
-  L["CONFIG_SELLING_GEAR_USE_ILVL"] = "For gear, use item level when selecting the price to compete with"
-  L["CONFIG_SELLING_GEAR_USE_ILVL_TOOLTIP_HEADER"] = "Use Item Level"
-  L["CONFIG_SELLING_GEAR_USE_ILVL_TOOLTIP_TEXT"] = "Normally gear is compared with any other gear that is similar, but without taking item level into account. This will make the item level be taken into account."
 
   L["CLASSIC_SUPPORT_ERROR"] = "This version of Auctionator DOES NOT support Classic. Stuff may break and not work."
 

--- a/Source/Config/Frames/NotLIFO.xml
+++ b/Source/Config/Frames/NotLIFO.xml
@@ -130,17 +130,6 @@
           <Anchor point="TOPLEFT" relativeKey="$parent.GearPriceMultiplierHeading" relativePoint="BOTTOMLEFT" y="-15"/>
         </Anchors>
       </Frame>
-
-      <Frame inherits="AuctionatorConfigurationCheckbox" parentKey="GearUseItemLevel">
-        <KeyValues>
-          <KeyValue key="labelText" value="AUCTIONATOR_L_CONFIG_SELLING_GEAR_USE_ILVL" type="global" />
-          <KeyValue key="tooltipTitleText" value="AUCTIONATOR_L_CONFIG_SELLING_GEAR_USE_ILVL_TOOLTIP_HEADER" type="global" />
-          <KeyValue key="tooltipText" value="AUCTIONATOR_L_CONFIG_SELLING_GEAR_USE_ILVL_TOOLTIP_TEXT" type="global"/>
-        </KeyValues>
-        <Anchors>
-          <Anchor point="TOPLEFT" relativeKey="$parent.GearPriceMultiplier" relativePoint="BOTTOMLEFT" />
-        </Anchors>
-      </Frame>
     </Frames>
   </Frame>
 </Ui>

--- a/Source/Config/Main.lua
+++ b/Source/Config/Main.lua
@@ -33,7 +33,6 @@ Auctionator.Config.Options = {
   NOT_LIFO_UNDERCUT_STATIC_VALUE = "not_lifo_undercut_static_value",
   NOT_LIFO_DEFAULT_QUANTITY = "not_lifo_default_quantity",
   GEAR_PRICE_MULTIPLIER = "gear_vendor_price_multiplier",
-  SELLING_GEAR_USE_ILVL = "gear_use_ilvl",
 
   LIFO_AUCTION_DURATION = "lifo_auction_duration",
   LIFO_AUCTION_SALES_PREFERENCE = "lifo_auction_sales_preference",
@@ -107,7 +106,6 @@ local defaults = {
   [Auctionator.Config.Options.NOT_LIFO_UNDERCUT_STATIC_VALUE] = 0,
   [Auctionator.Config.Options.NOT_LIFO_DEFAULT_QUANTITY] = 1,
   [Auctionator.Config.Options.GEAR_PRICE_MULTIPLIER] = 0,
-  [Auctionator.Config.Options.SELLING_GEAR_USE_ILVL] = false,
 
   [Auctionator.Config.Options.LIFO_AUCTION_DURATION] = 24,
   [Auctionator.Config.Options.LIFO_AUCTION_SALES_PREFERENCE] = Auctionator.Config.SalesTypes.PERCENTAGE,

--- a/Source/Config/Mixins/NotLIFO.lua
+++ b/Source/Config/Mixins/NotLIFO.lua
@@ -27,7 +27,6 @@ function AuctionatorConfigNotLIFOFrameMixin:OnShow()
 
   self.DefaultQuantity:SetNumber(Auctionator.Config.Get(Auctionator.Config.Options.NOT_LIFO_DEFAULT_QUANTITY))
   self.GearPriceMultiplier:SetNumber(Auctionator.Config.Get(Auctionator.Config.Options.GEAR_PRICE_MULTIPLIER))
-  self.GearUseItemLevel:SetChecked(Auctionator.Config.Get(Auctionator.Config.Options.SELLING_GEAR_USE_ILVL))
 end
 
 function AuctionatorConfigNotLIFOFrameMixin:OnSalesPreferenceChange(selectedValue)
@@ -57,7 +56,6 @@ function AuctionatorConfigNotLIFOFrameMixin:Save()
   Auctionator.Config.Set(Auctionator.Config.Options.NOT_LIFO_DEFAULT_QUANTITY, self.DefaultQuantity:GetNumber())
 
   Auctionator.Config.Set(Auctionator.Config.Options.GEAR_PRICE_MULTIPLIER, self.GearPriceMultiplier:GetNumber())
-  Auctionator.Config.Set(Auctionator.Config.Options.SELLING_GEAR_USE_ILVL, self.GearUseItemLevel:GetChecked())
 end
 
 function AuctionatorConfigNotLIFOFrameMixin:Cancel()

--- a/Source/Tabs/DataProviders/SearchProvider.lua
+++ b/Source/Tabs/DataProviders/SearchProvider.lua
@@ -84,9 +84,10 @@ function AuctionatorSearchDataProviderMixin:OnHide()
   })
 end
 
-function AuctionatorSearchDataProviderMixin:ReceiveEvent(eventName)
+function AuctionatorSearchDataProviderMixin:ReceiveEvent(eventName, ...)
   if eventName == Auctionator.Selling.Events.SellSearchStart then
     self:Reset()
+    self.expectedItemLevel = ...
     self.onSearchStarted()
   elseif eventName == Auctionator.Selling.Events.BagItemClicked then
     self.onResetScroll()
@@ -161,6 +162,14 @@ local function cancelShortcutEnabled()
   return Auctionator.Config.Get(Auctionator.Config.Options.SELLING_CANCEL_SHORTCUT) ~= Auctionator.Config.Shortcuts.NONE
 end
 
+function AuctionatorSearchDataProviderMixin:ExpectedResult(itemKey)
+  if self.expectedItemLevel ~= nil then
+    return itemKey.itemLevel == self.expectedItemLevel
+  else
+    return true
+  end
+end
+
 function AuctionatorSearchDataProviderMixin:ProcessCommodityResults(itemID)
   local entries = {}
   local anyOwnedNotLoaded = false
@@ -217,43 +226,45 @@ function AuctionatorSearchDataProviderMixin:ProcessItemResults(itemKey)
 
   for index = C_AuctionHouse.GetNumItemSearchResults(itemKey), 1, -1 do
     local resultInfo = C_AuctionHouse.GetItemSearchResultInfo(itemKey, index)
-    local entry = {
-      price = resultInfo.buyoutAmount,
-      bidPrice = resultInfo.bidAmount,
-      level = tostring(resultInfo.itemKey.itemLevel or 0),
-      owners = resultInfo.owners,
-      otherSellers = Auctionator.Utilities.StringJoin(resultInfo.owners, ", "),
-      timeLeftPretty = Auctionator.Utilities.FormatTimeLeftBand(resultInfo.timeLeft),
-      timeLeft = resultInfo.timeLeft, --Used in sorting and the vanilla AH tooltip code
-      quantity = resultInfo.quantity,
-      quantityFormatted = Auctionator.Utilities.DelimitThousands(resultInfo.quantity),
-      itemLink = resultInfo.itemLink,
-      auctionID = resultInfo.auctionID,
-      itemType = Auctionator.Constants.ITEM_TYPES.ITEM,
-      canBuy = resultInfo.buyoutAmount ~= nil and not (resultInfo.containsOwnerItem or resultInfo.containsAccountItem)
-    }
+    if self:ExpectedResult(resultInfo.itemKey) then
+      local entry = {
+        price = resultInfo.buyoutAmount,
+        bidPrice = resultInfo.bidAmount,
+        level = tostring(resultInfo.itemKey.itemLevel or 0),
+        owners = resultInfo.owners,
+        otherSellers = Auctionator.Utilities.StringJoin(resultInfo.owners, ", "),
+        timeLeftPretty = Auctionator.Utilities.FormatTimeLeftBand(resultInfo.timeLeft),
+        timeLeft = resultInfo.timeLeft, --Used in sorting and the vanilla AH tooltip code
+        quantity = resultInfo.quantity,
+        quantityFormatted = Auctionator.Utilities.DelimitThousands(resultInfo.quantity),
+        itemLink = resultInfo.itemLink,
+        auctionID = resultInfo.auctionID,
+        itemType = Auctionator.Constants.ITEM_TYPES.ITEM,
+        canBuy = resultInfo.buyoutAmount ~= nil and not (resultInfo.containsOwnerItem or resultInfo.containsAccountItem)
+      }
 
-    if resultInfo.itemKey.battlePetSpeciesID ~= 0 and entry.itemLink ~= nil then
-      entry.level = tostring(Auctionator.Utilities.GetPetLevelFromLink(entry.itemLink))
-    end
-
-    local qualityColor = Auctionator.Utilities.GetQualityColorFromLink(entry.itemLink)
-    entry.level = "|c" .. qualityColor .. entry.level .. "|r"
-
-    if resultInfo.containsOwnerItem then
-      -- Test if the auction has been loaded for cancelling
-      if not C_AuctionHouse.CanCancelAuction(resultInfo.auctionID) then
-        anyOwnedNotLoaded = true
+      if resultInfo.itemKey.battlePetSpeciesID ~= 0 and entry.itemLink ~= nil then
+        entry.level = tostring(Auctionator.Utilities.GetPetLevelFromLink(entry.itemLink))
       end
 
-      entry.otherSellers = GREEN_FONT_COLOR:WrapTextInColorCode(AUCTION_HOUSE_SELLER_YOU)
-      entry.owned = AUCTIONATOR_L_UNDERCUT_YES
+      local qualityColor = Auctionator.Utilities.GetQualityColorFromLink(entry.itemLink)
+      entry.level = "|c" .. qualityColor .. entry.level .. "|r"
 
-    else
-      entry.owned = GRAY_FONT_COLOR:WrapTextInColorCode(AUCTIONATOR_L_UNDERCUT_NO)
+      if resultInfo.containsOwnerItem then
+        -- Test if the auction has been loaded for cancelling
+        if not C_AuctionHouse.CanCancelAuction(resultInfo.auctionID) then
+          anyOwnedNotLoaded = true
+        end
+
+        entry.otherSellers = GREEN_FONT_COLOR:WrapTextInColorCode(AUCTION_HOUSE_SELLER_YOU)
+        entry.owned = AUCTIONATOR_L_UNDERCUT_YES
+
+      else
+        entry.owned = GRAY_FONT_COLOR:WrapTextInColorCode(AUCTIONATOR_L_UNDERCUT_NO)
+      end
+
+      table.insert(entries, entry)
     end
-
-    table.insert(entries, entry)
   end
 
   -- See comment in ProcessCommodityResults

--- a/Source/Tabs/Selling/Mixins/SaleItem.lua
+++ b/Source/Tabs/Selling/Mixins/SaleItem.lua
@@ -292,16 +292,22 @@ function AuctionatorSaleItemMixin:DoSearch(itemInfo, ...)
     sortingOrder = {sortOrder = 4, reverseSort = false}
   end
 
-  if IsEquipment(itemInfo) and not Auctionator.Config.Get(Auctionator.Config.Options.SELLING_GEAR_USE_ILVL) then
+  if IsEquipment(itemInfo) then
     -- Bug with PTR C_AuctionHouse.MakeItemKey(...), it always sets the
     -- itemLevel to a non-zero value, so we have to create the key directly
     self.expectedItemKey = {itemID = itemInfo.itemKey.itemID, itemLevel = 0, itemSuffix = 0, battlePetSpeciesID = 0}
+    if itemInfo.itemKey.itemLevel >= Auctionator.Constants.ITEM_LEVEL_THRESHOLD then
+      self.expectedItemLevel = itemInfo.itemKey.itemLevel
+    else
+      self.expectedItemLevel = nil
+    end
     Auctionator.AH.SendSellSearchQuery(self.expectedItemKey, {sortingOrder}, true)
   else
     self.expectedItemKey = itemInfo.itemKey
+    self.expectedItemLevel = nil
     Auctionator.AH.SendSearchQuery(itemInfo.itemKey, {sortingOrder}, true)
   end
-  Auctionator.EventBus:Fire(self, Auctionator.Selling.Events.SellSearchStart)
+  Auctionator.EventBus:Fire(self, Auctionator.Selling.Events.SellSearchStart, self.expectedItemLevel)
 end
 
 function AuctionatorSaleItemMixin:Reset()
@@ -407,8 +413,23 @@ function AuctionatorSaleItemMixin:ProcessCommodityResults(itemID, ...)
 end
 
 function AuctionatorSaleItemMixin:GetItemResult(itemKey)
-  if C_AuctionHouse.GetItemSearchResultsQuantity(itemKey) > 0 then
-    return C_AuctionHouse.GetItemSearchResultInfo(itemKey, 1)
+  local resultsQuantity = C_AuctionHouse.GetItemSearchResultsQuantity(itemKey)
+  if resultsQuantity > 0 then
+    -- Get the first item to match the item level requirement
+    if self.expectedItemLevel ~= nil then
+      local index = 1
+      while index <= resultsQuantity do
+        result = C_AuctionHouse.GetItemSearchResultInfo(itemKey, index)
+        if result.itemKey.itemLevel == self.expectedItemLevel then
+          return result
+        end
+        index = index + 1
+      end
+      return nil
+    -- We don't have an item level to compare to, so get the first result
+    else
+      return C_AuctionHouse.GetItemSearchResultInfo(itemKey, 1)
+    end
   else
     return nil
   end


### PR DESCRIPTION
…ption

Item level checks now accomodate gear variants
Instead of the option all gear of at least ilvl 168 is automatically
done by item level only