### PR TITLE
[Fixes #969] Skip button for posting in Selling tab

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -335,6 +335,7 @@ AUCTIONATOR_LOCALES.enUS = function()
   L["BIDDER"] = "Bidder"
   L["DURATION"] = "Duration"
   L["POST"] = "Post"
+  L["SKIP"] = "Skip"
   L["DEPOSIT"] = "Deposit:"
   L["TOTAL_PRICE"] = "Total Price:"
 
@@ -376,6 +377,7 @@ AUCTIONATOR_LOCALES.enUS = function()
   L["CONFIG_SELLING_POST_SHORTCUT"] = "A keyboard/mouse shortcut to post the current item is"
   L["CUSTOM_KEYBOARD_SHORTCUTS"] = "Custom keyboard shortcuts"
   L["CONFIG_SELLING_POST_SHORTCUT_TOOLTIP_TEXT"] = "Click and then press the buttons that you wish to use as the shortcut. This shortcut will only be active in the Selling tab and won't affect any other shortcuts bound to the buttons."
+  L["CONFIG_SELLING_SKIP_SHORTCUT"] = "A shortcut to skip posting the currently selected item is"
   L["CONFIG_BAG"] = "Bag"
 
   L["HIDE"] = "Hide"

--- a/Source/Components/Frames/KeyBinding.xml
+++ b/Source/Components/Frames/KeyBinding.xml
@@ -27,7 +27,7 @@
     </Scripts>
   </Button>
   <Frame name="AuctionatorKeyBindingConfigTemplate" mixin="AuctionatorKeyBindingConfigMixin" virtual="true">
-    <Size x="400" y="25"/>
+    <Size x="400" y="35"/>
     <Layers>
       <Layer level="BACKGROUND">
         <FontString inherits="GameFontHighlight" parentKey="Description" justifyH="LEFT">

--- a/Source/Config/Frames/SellingShortcuts.xml
+++ b/Source/Config/Frames/SellingShortcuts.xml
@@ -57,6 +57,16 @@
           <KeyValue key="tooltipTitleText" value="AUCTIONATOR_L_CUSTOM_KEYBOARD_SHORTCUTS" type="global"/>
         </KeyValues>
       </Frame>
+      <Frame parentKey="SkipShortcut" inherits="AuctionatorKeyBindingConfigTemplate">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.PostShortcut"/>
+        </Anchors>
+        <KeyValues>
+          <KeyValue key="labelText" value="AUCTIONATOR_L_CONFIG_SELLING_SKIP_SHORTCUT" type="global"/>
+          <KeyValue key="tooltipText" value="AUCTIONATOR_L_CONFIG_SELLING_POST_SHORTCUT_TOOLTIP_TEXT" type="global"/>
+          <KeyValue key="tooltipTitleText" value="AUCTIONATOR_L_CUSTOM_KEYBOARD_SHORTCUTS" type="global"/>
+        </KeyValues>
+      </Frame>
     </Frames>
   </Frame>
 </Ui>

--- a/Source/Config/Main.lua
+++ b/Source/Config/Main.lua
@@ -27,6 +27,7 @@ Auctionator.Config.Options = {
   SELLING_AUTO_SELECT_NEXT = "selling_auto_select_next",
   SELLING_MISSING_FAVOURITES = "selling_missing_favourites",
   SELLING_POST_SHORTCUT = "selling_post_shortcut",
+  SELLING_SKIP_SHORTCUT = "selling_skip_shortcut",
 
   NOT_LIFO_AUCTION_DURATION = "not_lifo_auction_duration",
   NOT_LIFO_AUCTION_SALES_PREFERENCE = "not_lifo_auction_sales_preference",
@@ -103,6 +104,7 @@ local defaults = {
   [Auctionator.Config.Options.SELLING_AUTO_SELECT_NEXT] = false,
   [Auctionator.Config.Options.SELLING_MISSING_FAVOURITES] = true,
   [Auctionator.Config.Options.SELLING_POST_SHORTCUT] = "",
+  [Auctionator.Config.Options.SELLING_SKIP_SHORTCUT] = "",
 
   [Auctionator.Config.Options.NOT_LIFO_AUCTION_DURATION] = 48,
   [Auctionator.Config.Options.NOT_LIFO_AUCTION_SALES_PREFERENCE] = Auctionator.Config.SalesTypes.PERCENTAGE,

--- a/Source/Config/Mixins/SellingShortcuts.lua
+++ b/Source/Config/Mixins/SellingShortcuts.lua
@@ -15,6 +15,7 @@ function AuctionatorConfigSellingShortcutsFrameMixin:OnShow()
   self.BuyShortcut:SetValue(Auctionator.Config.Get(Auctionator.Config.Options.SELLING_BUY_SHORTCUT))
 
   self.PostShortcut:SetShortcut(Auctionator.Config.Get(Auctionator.Config.Options.SELLING_POST_SHORTCUT))
+  self.SkipShortcut:SetShortcut(Auctionator.Config.Get(Auctionator.Config.Options.SELLING_SKIP_SHORTCUT))
 end
 
 function AuctionatorConfigSellingShortcutsFrameMixin:Save()
@@ -25,6 +26,7 @@ function AuctionatorConfigSellingShortcutsFrameMixin:Save()
   Auctionator.Config.Set(Auctionator.Config.Options.SELLING_BUY_SHORTCUT, self.BuyShortcut:GetValue())
 
   Auctionator.Config.Set(Auctionator.Config.Options.SELLING_POST_SHORTCUT, self.PostShortcut:GetShortcut())
+  Auctionator.Config.Set(Auctionator.Config.Options.SELLING_SKIP_SHORTCUT, self.SkipShortcut:GetShortcut())
 end
 
 function AuctionatorConfigSellingShortcutsFrameMixin:UnhideAllClicked()

--- a/Source/Tabs/Selling/Frames/SaleItem.xml
+++ b/Source/Tabs/Selling/Frames/SaleItem.xml
@@ -114,13 +114,22 @@
         </Frames>
       </Frame>
 
-      <Button parentKey="PostButton" name="AuctionatorPostButton" inherits="UIPanelDynamicResizeButtonTemplate" text="AUCTIONATOR_L_POST">
+      <Button parentKey="PostButton" name="AuctionatorPostButton" inherits="UIPanelButtonTemplate" text="AUCTIONATOR_L_POST">
         <Size x="194" y="22"/>
         <Anchors>
           <Anchor point="TOPLEFT" relativeKey="$parent.Duration" relativePoint="BOTTOMLEFT" x="20" />
         </Anchors>
         <Scripts>
           <OnClick>self:GetParent():PostItem()</OnClick>
+        </Scripts>
+      </Button>
+      <Button parentKey="SkipButton" name="AuctionatorSkipPostingButton" inherits="UIPanelButtonTemplate" text="AUCTIONATOR_L_SKIP" hidden="true">
+        <Size x="80" y="22"/>
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeKey="$parent.PostButton" relativePoint="TOPRIGHT"/>
+        </Anchors>
+        <Scripts>
+          <OnClick>self:GetParent():SkipItem()</OnClick>
         </Scripts>
       </Button>
     </Frames>


### PR DESCRIPTION
Skip button for the Selling tab (shown only when the "Automatically select the next item in your bag" option is on)
![image](https://user-images.githubusercontent.com/60280559/109433385-f5ac4680-7a07-11eb-816b-c8edf8258408.png)
