### PR TITLE
vendor price for [Korthite Crystal]

### DIFF
--- a/Source/Constants/ItemInfo.lua
+++ b/Source/Constants/ItemInfo.lua
@@ -3,5 +3,6 @@ Auctionator.Constants.ITEM_INFO = {
   SELL_PRICE = 11,
   CLASS = 12,
   BIND_TYPE = 14,
-  XPAC = 15, 
+  XPAC = 15,
+  REAGENT = 17,
 }

--- a/Source/Tooltips/Main.lua
+++ b/Source/Tooltips/Main.lua
@@ -47,9 +47,10 @@ function Auctionator.Tooltip.ShowTipWithPricingDBKey(tooltipFrame, dbKeys, itemL
     local bindType = itemInfo[Auctionator.Constants.ITEM_INFO.BIND_TYPE]
     cannotAuction = bindType == LE_ITEM_BIND_ON_ACQUIRE or bindType == LE_ITEM_BIND_QUEST;
     local sellPrice = itemInfo[Auctionator.Constants.ITEM_INFO.SELL_PRICE]
+    local isReagent = itemInfo[Auctionator.Constants.ITEM_INFO.REAGENT]
     local isArtifact = itemInfo[Auctionator.Constants.ITEM_INFO.RARITY] == Enum.ItemQuality.Artifact
     local isLegendary = itemInfo[Auctionator.Constants.ITEM_INFO.RARITY] == Enum.ItemQuality.Legendary
-    if sellPrice ~= nil and not isArtifact and not isLegendary then
+    if sellPrice ~= nil and not isArtifact and (isReagent or not isLegendary) then
       vendorPrice = sellPrice * (showStackPrices and itemCount or 1);
     end
 


### PR DESCRIPTION
you might want to handle this another way but currently the [Korthite Crystal] vendor price isn't handled by Auctionator, as it detects it as a Legendary and it's skipped over. this fixes that by simply doing an `isReagent or not isLegendary` check.