### PR TITLE
build(deps-dev): bump actions/checkout from 1 to 2

### DIFF
--- a/.github/workflows/curse.yml
+++ b/.github/workflows/curse.yml
@@ -17,7 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Setup Retail build
       run: mv Auctionator_Mainline.toc Auctionator.toc


### PR DESCRIPTION
Bump actions/checkout GitHub Actions from v1 to v3.
[Changelog can be found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md).