### PR TITLE
Fixed incorrect pending auction calculation on cancelling tab.

### DIFF
--- a/Source_Mainline/Tabs/DataProviders/Cancelling.lua
+++ b/Source_Mainline/Tabs/DataProviders/Cancelling.lua
@@ -215,7 +215,7 @@ function AuctionatorCancellingDataProviderMixin:PopulateAuctions()
         })
       end
     elseif self:IsSoldAuction(info) then
-      totalPending = totalPending + price * info.quantity
+      totalPending = totalPending + price
     end
   end
   self:AppendEntries(results, true)


### PR DESCRIPTION
The pending gold amount on the auction cancelling tab has an issue where values are incorrectly calculated as being larger than what they should be. This appears to be due to the auction buyout amount being multiplied by the auction quantity in the tab's DataProvider. Multiplying by the quantity does not appear to be necessary, as the buyout amount reflects the total gold amount already for sold auctions. Making the change included in this request fixes the issue on retail.

Also this is my first pull request so apologies if I have done anything incorrectly!