### PR TITLE
Abort Shopping scan when user clicks item in ResultsListing

### DIFF
--- a/Source/Shopping/Events.lua
+++ b/Source/Shopping/Events.lua
@@ -21,4 +21,7 @@ Auctionator.Shopping.Tab.Events = {
   ShowHistoricalPrices = "shopping show historical prices",
   UpdateSearchTerm = "shopping update search term",
   ListSearchRequested = "shopping list search requested",
+
+  -- For classic compatability
+  ShowBuyForShopping = "buying_show_for_shopping"
 }

--- a/Source/Tabs/Shopping/Mixins/Main.lua
+++ b/Source/Tabs/Shopping/Mixins/Main.lua
@@ -5,6 +5,7 @@ local EVENTBUS_EVENTS = {
   Auctionator.Shopping.Tab.Events.ListSearchRequested,
   Auctionator.Shopping.Tab.Events.ShowHistoricalPrices,
   Auctionator.Shopping.Tab.Events.UpdateSearchTerm,
+  Auctionator.Shopping.Tab.Events.ShowBuyForShopping,
 }
 
 function AuctionatorShoppingTabFrameMixin:DoSearch(terms, options)
@@ -254,6 +255,12 @@ function AuctionatorShoppingTabFrameMixin:ReceiveEvent(eventName, eventData)
 
   elseif eventName == Auctionator.Shopping.Tab.Events.UpdateSearchTerm then
     self.SearchOptions:SetSearchTerm(eventData)
+
+  elseif eventName == Auctionator.Shopping.Tab.Events.ShowBuyForShopping then
+    if self.searchRunning then
+      self:StopSearch()
+    end
+
   end
 end
 


### PR DESCRIPTION
Fixes #1479.  

The Buying events are located in `Source_Classic` which I could not find a way to reference from the `Source` folder, so I added a duplicate entry for the `ShowBuyForShopping` event in the `Source` shopping events.  This breaks the separation of the Classic-only features, so I'm open to suggestions for a better way to handle this.