### PR TITLE
GetAuctionPriceByItemID with ItemLevel

### DIFF
--- a/Source/API/v1/GetAuctionPrice.lua
+++ b/Source/API/v1/GetAuctionPrice.lua
@@ -1,4 +1,4 @@
-function Auctionator.API.v1.GetAuctionPriceByItemID(callerID, itemID)
+function Auctionator.API.v1.GetAuctionPriceByItemID(callerID, itemID, itemLevel)
   Auctionator.API.InternalVerifyID(callerID)
 
   if type(itemID) ~= "number" then
@@ -8,11 +8,24 @@ function Auctionator.API.v1.GetAuctionPriceByItemID(callerID, itemID)
     )
   end
 
+  if itemLevel ~= nil and type(itemLevel) ~= "number" then
+    Auctionator.API.ComposeError(
+      callerID,
+      "Usage Auctionator.API.v1.GetAuctionPriceByItemID(string, number, number)"
+    )
+  end
+
   if Auctionator.Database == nil then
     return nil
   end
 
-  return Auctionator.Database:GetPrice(tostring(itemID))
+  local dbKey = tostring(itemID)
+
+  if itemLevel ~= nil then
+    dbKey = 'g:' .. itemID .. ':' .. itemLevel
+  end
+
+  return Auctionator.Database:GetPrice(dbKey)
 end
 
 function Auctionator.API.v1.GetAuctionPriceByItemLink(callerID, itemLink)

--- a/Source/Database/Mixin.lua
+++ b/Source/Database/Mixin.lua
@@ -53,10 +53,18 @@ function Auctionator.DatabaseMixin:_Get(dbKey)
 
   local data = self.db[dbKey]
   if type(data) == "string" then
-    return LibCBOR:Deserialize(data)
-  else
-    return data
+    data = LibCBOR:Deserialize(data)
+    if data == nil then
+      data = {
+        l={}, -- Lowest low price on a given day
+        h={}, -- Highest low price on a given day
+        a={}, -- Highest quantity seen on a given day
+        m=0   -- Last seen minimum price
+      }
+    end
   end
+  
+  return data
 end
 
 function Auctionator.DatabaseMixin:_Queue(dbKey)
@@ -93,9 +101,19 @@ function Auctionator.DatabaseMixin:_SetPrice(dbKey, buyoutPrice, available)
   end
 
   local priceData = self.db[dbKey]
+  
   if type(priceData) == "string" then
     priceData = LibCBOR:Deserialize(priceData)
-  end
+    if priceData == nil then
+      priceData = {
+        l={}, -- Lowest low price on a given day
+        h={}, -- Highest low price on a given day
+        a={}, -- Highest quantity seen on a given day
+        m=0   -- Last seen minimum price
+      }
+    end
+  end  
+
   priceData.m = buyoutPrice
 
   -- Record price history

--- a/Source/Tooltips/Main.lua
+++ b/Source/Tooltips/Main.lua
@@ -176,7 +176,7 @@ function Auctionator.Tooltip.AddVendorTip(tooltipFrame, vendorPrice, countString
     tooltipFrame:AddDoubleLine(
       L("VENDOR") .. countString,
       WHITE_FONT_COLOR:WrapTextInColorCode(
-        Auctionator.Utilities.CreatePaddedMoneyString(vendorPrice)
+        Auctionator.Utilities.CreatePaddedMoneyString(vendorPrice, false, false)
       )
     )
   end
@@ -191,7 +191,7 @@ function Auctionator.Tooltip.AddAuctionTip (tooltipFrame, auctionPrice, countStr
       tooltipFrame:AddDoubleLine(
         L("AUCTION") .. countString,
         WHITE_FONT_COLOR:WrapTextInColorCode(
-          Auctionator.Utilities.CreatePaddedMoneyString(auctionPrice)
+          Auctionator.Utilities.CreatePaddedMoneyString(auctionPrice, false, false)
         )
       )
     else

--- a/Source/Utilities/CreatePaddedMoneyString.lua
+++ b/Source/Utilities/CreatePaddedMoneyString.lua
@@ -16,27 +16,41 @@ local copperIcon = "|TInterface\\MoneyFrame\\UI-CopperIcon:12:12:0:0|t"
 local leftPadding = " "
 local rightPadding = " "
 
-function Auctionator.Utilities.CreatePaddedMoneyString(amount)
+function Auctionator.Utilities.CreatePaddedMoneyString(amount, showSilver, showCopper)
   amount = math.floor(amount)
 
   local gold, silver, copper = getGold(amount), getSilver(amount), getCopper(amount)
 
-  local result = copper .. leftPadding .. copperIcon
+  local paddedCopper = copper
+  if copper < 10 then
+    paddedCopper = "0" .. copper
+  end
 
-  if (gold ~= 0 or silver ~= 0) and copper < 10 then
-    result = "0" .. result
+  local paddedSilver = silver
+  if silver < 10 then
+    paddedSilver = "0" .. silver
+  end
+  
+  local result = ''
+  
+  if showCopper == true or showCopper == nil then
+    result = paddedCopper .. rightPadding .. copperIcon
   end
 
   if silver ~= 0 or gold ~= 0 then
-    result = silver .. leftPadding .. silverIcon .. rightPadding .. result
-  end
-
-  if gold ~= 0 and silver < 10 then
-    result = "0" .. result
+    if showSilver == true or showSilver == nil then
+      if result ~= '' then
+        result = rightPadding .. result
+      end
+      result = paddedSilver .. leftPadding .. silverIcon .. result
+    end
   end
 
   if gold ~= 0 then
-    result = gold .. leftPadding .. goldIcon .. rightPadding ..result
+    if result ~= '' then
+      result = rightPadding .. result
+    end
+    result = gold .. leftPadding .. goldIcon .. result
   end
 
   return result

--- a/Source_Mainline/Tabs/Selling/Frames/SaleItem.xml
+++ b/Source_Mainline/Tabs/Selling/Frames/SaleItem.xml
@@ -101,6 +101,17 @@
           <OnClick>self:GetParent():PostItem()</OnClick>
         </Scripts>
       </Button>
+      
+      <Button parentKey="PostAllButton" name="AuctionatorPostButton" inherits="UIPanelButtonTemplate" text="AUCTIONATOR_L_POST">
+        <Size x="194" y="22"/>
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeKey="$parent.Duration" relativePoint="BOTTOMLEFT" x="20" y="70"/>
+        </Anchors>
+        <Scripts>
+          <OnClick>self:GetParent():PostAllItems()</OnClick>
+        </Scripts>
+      </Button>
+
       <Button parentKey="SkipButton" name="AuctionatorSkipPostingButton" inherits="UIPanelButtonTemplate" text="AUCTIONATOR_L_SKIP" hidden="true">
         <Size x="80" y="22"/>
         <Anchors>

--- a/Source_Mainline/Tabs/Selling/Mixins/SaleItem.lua
+++ b/Source_Mainline/Tabs/Selling/Mixins/SaleItem.lua
@@ -668,6 +668,36 @@ function AuctionatorSaleItemMixin:GetDuration()
   return AUCTION_DURATIONS[self.Duration:GetValue()]
 end
 
+function AuctionatorSaleItemMixin:PostAllItems()
+  local duration = 1
+  local quantity = 1
+  
+  for bagId = BACKPACK_CONTAINER, NUM_TOTAL_EQUIPPED_BAG_SLOTS do
+    for slotId = 1, C_Container.GetContainerNumSlots(bagId) do
+      local itemLink = C_Container.GetContainerItemLink(bagId, slotId)
+      if itemLink then
+        local itemID = C_Item.GetItemIDForItemInfo(itemLink)
+        local itemName, itemLink, itemRarity, itemLevel = GetItemInfo(itemLink)
+        local craftData = CraftInfoAnywhere.API.GetData(itemID, itemLevel) 
+        
+        if craftData and craftData.auctionPrice then        
+          local location = ItemLocation:CreateFromBagAndSlot(bagId, slotId)  
+          local buyout = craftData.auctionPrice                    
+          local action = '?'
+
+          C_AuctionHouse.PostItem(location, duration, quantity, nil, buyout)
+          
+          local dsbuyout = Auctionator.Utilities.CreatePaddedMoneyString(buyout, false, false)
+          local dsprofit = Auctionator.Utilities.CreatePaddedMoneyString(craftData.profit, false, false)
+
+          print('[Posted]', itemLink, 'for', dsbuyout, ' -> profit: ', dsprofit)
+          return
+        end
+      end
+    end
+  end
+end
+
 function AuctionatorSaleItemMixin:PostItem(confirmed)
   if not self:GetPostButtonState() then
     Auctionator.Debug.Message("Trying to post when we can't. Returning")

--- a/Source_Mainline/Tabs/Selling/Mixins/SaleItem.lua
+++ b/Source_Mainline/Tabs/Selling/Mixins/SaleItem.lua
@@ -521,6 +521,37 @@ function AuctionatorSaleItemMixin:ProcessCommodityResults(itemID, ...)
     return
   end
 
+  if self.itemInfo then
+    local qtresults = C_AuctionHouse.GetNumCommoditySearchResults(itemID)
+    if qtresults > 15 then qtresults = 15 end
+
+    local biggestStack = 0
+    local biggestStackPrice = 0
+
+    for index = 1, qtresults do
+      local resultInfo = C_AuctionHouse.GetCommoditySearchResultInfo(itemID, index)
+      if resultInfo.quantity > biggestStack then
+        biggestStack = resultInfo.quantity
+        biggestStackPrice = resultInfo.unitPrice
+      end
+    end
+
+    local dsbigstack = Auctionator.Utilities.CreatePaddedMoneyString(biggestStackPrice, true, false)
+
+    local minGoodPrice = biggestStackPrice * 0.95
+
+    for index = 1, qtresults do
+      local resultInfo = C_AuctionHouse.GetCommoditySearchResultInfo(itemID, index)
+      if resultInfo.unitPrice >= minGoodPrice then
+        local prOff = (biggestStackPrice - resultInfo.unitPrice) / biggestStackPrice * 100
+        local dsoff = string.format('%.0f', prOff)..'%'
+        -- print(self.itemInfo.itemLink, dsbigstack, '...', dsoff, '...', '#'..index, '...', Auctionator.Utilities.CreatePaddedMoneyString(resultInfo.unitPrice, true, false))
+        self:UpdateSalesPrice(resultInfo.unitPrice)
+        return
+      end
+    end
+  end
+  
   self:UpdateSalesPrice(postingPrice)
 end
 


### PR DESCRIPTION
Pretty simple stuff.

Right now when you can the API.GetAuctionPriceByItemID, it'll search on the DB by itemID alone. This change add a new (optional) parameter that, if present, will search for a composed dbKey.