### PR TITLE
Changelog: Tooltip Price for Crafted Gear by Item Level

### DIFF
--- a/Source/Tooltips/Hooks.lua
+++ b/Source/Tooltips/Hooks.lua
@@ -267,6 +267,19 @@ end
 
 if GameTooltip.SetItemKey then
   TooltipHandlers["SetItemKey"] = function(tip, itemID, itemLevel, itemSuffix)
+    -- Use itemKey for price lookup so itemLevel is preserved (AH, crafting UI)
+    if Auctionator.Constants.IsRetail and Auctionator.Utilities.DBKeysFromItemKey then
+      local itemKey = {itemID = itemID, itemLevel = itemLevel or 0, itemSuffix = itemSuffix or 0, battlePetSpeciesID = 0}
+      local dbKeys = Auctionator.Utilities.DBKeysFromItemKey(itemKey)
+      if #dbKeys > 0 then
+        local info = C_TooltipInfo and C_TooltipInfo.GetItemKey(itemID, itemLevel or 0, itemSuffix or 0)
+        local itemLink = info and info.hyperlink or select(2, C_Item.GetItemInfo(itemID))
+        if itemLink then
+          Auctionator.Tooltip.ShowTipWithPricingDBKey(tip, dbKeys, itemLink, 1)
+          return
+        end
+      end
+    end
     local itemLink
     if C_TooltipInfo then
       local info = C_TooltipInfo and C_TooltipInfo.GetItemKey(itemID, itemLevel, itemSuffix)

--- a/Source_Mainline/CraftingInfo/Professions.lua
+++ b/Source_Mainline/CraftingInfo/Professions.lua
@@ -14,6 +14,25 @@ function Auctionator.CraftingInfo.InitializeProfessionsFrame()
   end
 end
 
+-- Search through a list of items for the first matching the wantedQuality.
+-- Midnight Quality-12-Tier: wantedQuality 13/14 maps to index 1/2.
+local function GetItemIDByReagentQuality(possibleItemIDs, wantedQuality)
+  if #possibleItemIDs == 1 then
+    return possibleItemIDs[1]
+  end
+  -- Midnight enchants use quality 13 (Silver/Tier1) and 14 (Gold/Tier2)
+  if wantedQuality and wantedQuality >= 13 and wantedQuality <= 14 and possibleItemIDs[wantedQuality - 12] then
+    return possibleItemIDs[wantedQuality - 12]
+  end
+
+  for _, itemID in ipairs(possibleItemIDs) do
+    local quality = C_TradeSkillUI.GetItemReagentQualityByItemInfo(itemID)
+    if quality == wantedQuality then
+      return itemID
+    end
+  end
+end
+
 function Auctionator.CraftingInfo.DoTradeSkillReagentsSearch(schematicForm, quantity)
   local recipeInfo = schematicForm:GetRecipeInfo()
   local recipeID = recipeInfo.recipeID
@@ -98,20 +117,6 @@ end
 
 local function CalculateProfitFromCosts(currentAH, toCraft, count)
   return math.floor(math.floor(currentAH * count * Auctionator.Constants.AfterAHCut - toCraft) / 100) * 100
-end
-
--- Search through a list of items for the first matching the wantedQuality
-local function GetItemIDByReagentQuality(possibleItemIDs, wantedQuality)
-  if #possibleItemIDs == 1 then
-    return possibleItemIDs[1]
-  end
-
-  for _, itemID in ipairs(possibleItemIDs) do
-    local quality = C_TradeSkillUI.GetItemReagentQualityByItemInfo(itemID)
-    if quality == wantedQuality then
-      return itemID
-    end
-  end
 end
 
 local function GetEnchantProfit(schematicForm)

--- a/Source_ModernAH/Utilities/DBKeyFromBrowseResult.lua
+++ b/Source_ModernAH/Utilities/DBKeyFromBrowseResult.lua
@@ -3,6 +3,17 @@ local function IsGear(itemID)
   return Auctionator.Utilities.IsEquipment(classType)
 end
 
+-- Build DB keys from itemKey (itemID, itemLevel, itemSuffix) for price lookup.
+-- Preserves itemLevel for crafted gear so each ilvl tier shows its correct AH price.
+function Auctionator.Utilities.DBKeysFromItemKey(itemKey)
+  if not itemKey then return {} end
+  if (itemKey.battlePetSpeciesID or 0) ~= 0 then return {"p:" .. tostring(itemKey.battlePetSpeciesID)} end
+  if IsGear(itemKey.itemID) and (itemKey.itemLevel or 0) >= Auctionator.Constants.ITEM_LEVEL_THRESHOLD then
+    return {"g:" .. itemKey.itemID .. ":" .. (itemKey.itemLevel or 0), tostring(itemKey.itemID)}
+  end
+  return {tostring(itemKey.itemID)}
+end
+
 function Auctionator.Utilities.DBKeyFromBrowseResult(result)
   if result.itemKey.battlePetSpeciesID ~= 0 then
     return {"p:" .. tostring(result.itemKey.battlePetSpeciesID)}


### PR DESCRIPTION
Summary
This affected Auction House and Professions UI tooltip `Auction` line. Tooltips for crafted gear with multiple item levels (Rank 1/2/3, ilvl tiers) now show the correct auction price for the specific item being hovered instead of the lowest ilvl price. 

Changes
Source_ModernAH/Utilities/DBKeyFromBrowseResult.lua

- Added DBKeysFromItemKey() to build DB keys from itemKey so itemLevel is preserved instead of being lost via item links Source/Tooltips/Hooks.lua
- Updated SetItemKey handler (Retail) to use DBKeysFromItemKey and ShowTipWithPricingDBKey directly when an item link is available Source_Mainline/CraftingInfo/Professions.lua
- Moved GetItemIDByReagentQuality above its callers to fix nil errors Added handling for Midnight quality IDs 13/14
Scope: Retail only.