### PR TITLE
Show / hide the search button consistently even fresh after login

### DIFF
--- a/Source_Mainline/CraftingInfo/Mixins/ObjectiveTracker.lua
+++ b/Source_Mainline/CraftingInfo/Mixins/ObjectiveTracker.lua
@@ -6,7 +6,7 @@ function AuctionatorCraftingInfoObjectiveTrackerFrameMixin:OnLoad()
     "PLAYER_INTERACTION_MANAGER_FRAME_HIDE",
     "TRACKED_RECIPE_UPDATE",
   })
-  self:UpdateSearchButton()
+  self:ShowIfRelevant()
 
   local function Update()
     self:ShowIfRelevant()
@@ -32,7 +32,7 @@ function AuctionatorCraftingInfoObjectiveTrackerFrameMixin:UpdateSearchButton()
 end
 
 function AuctionatorCraftingInfoObjectiveTrackerFrameMixin:IsAnythingTracked()
-  return #C_TradeSkillUI.GetRecipesTracked(true) > 0 or #C_TradeSkillUI.GetRecipesTracked(false) > 0 
+  return #C_TradeSkillUI.GetRecipesTracked(true) > 0 or #C_TradeSkillUI.GetRecipesTracked(false) > 0
 end
 
 function AuctionatorCraftingInfoObjectiveTrackerFrameMixin:SearchButtonClicked()


### PR DESCRIPTION
The problem:
the search button (for tracked profession recipes) does not show up for me if I track a new recipe.

It DOES show up if I have a recipe tracked and reload!

Debugging this problem I found that this button should ONLY show up if `Auctionator.Config.Options.CRAFTING_INFO_SHOW` is set. Some time ago I deactivated this.

This PR fixes the problem that this button shows up on reload (or login) if the config is not set. This makes it consistent to tracking a recipe later!

Additonally I think there are 2 more problems:
- I didnt know that checking the box "Show crafting costs in the crafting view" makes this search button appear. Possible fixes:
-- Always show the search buttons
-- Add a new config for this search button with a clear explanation
-- Change the existing description of the checkbox to include the search button.
- No crafting cost is displayed in my profession window either - maybe CraftSim hides this? The search button is there though...

What do you think for the first problem? I could provide the code if you decide which option you like.